### PR TITLE
Internal refs for deploying known tasks

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -234,6 +234,22 @@ Additionally you can access the logs via the API:
       -H 'Authorization: Key 3e84744ab2714151b1db789df82b41c0021958fe4d77406e9c0947c34f5c5a70'
 
 
+Rolling Back
+------------
+
+While Freight doesn't formally offer a first-class rollback control, you can tell it to deploy the previous stable:
+
+.. code-block:: bash
+
+  curlish http://localhost:5000/api/0/tasks/ \
+      -H 'Authorization: Key 3e84744ab2714151b1db789df82b41c0021958fe4d77406e9c0947c34f5c5a70' \
+      -X POST \
+      -J app=example \
+      -J ref=:previous \
+      -J task=deploy \
+      -J user="user@example.com"
+
+
 Next Steps
 ----------
 


### PR DESCRIPTION
- :current will target the latest finished task
- :previous will target the previous (one before latest) finished task
   this will filter out any task matching :current's sha