### PR TITLE
Fix heroku deploy button

### DIFF
--- a/app.json
+++ b/app.json
@@ -14,12 +14,25 @@
       "description": "An API key used to communiate with the service.",
       "generator": "secret"
     },
-    "GOOGLE_CLIENT_ID": "",
-    "GOOGLE_CLIENT_SECRET": "",
+    "GOOGLE_CLIENT_ID": {
+      "description": "Go to https://console.developers.google.com/ to generate one"
+    },
+    "GOOGLE_CLIENT_SECRET": {},
     "GOOGLE_DOMAIN": {
       "description": "The Google Apps domain you wish to restrict login to"
     },
-    "SENTRY_DSN": "",
+    "GITHUB_TOKEN": {
+      "description": "The Google Apps domain you wish to restrict login to",
+      "required": false
+    },
+    "GITHUB_API_ROOT": {
+      "description": "The base URL for the API. Defaults to https://api.github.com",
+      "value": "https://api.github.com"
+    },
+    "SENTRY_DSN": {
+      "description": "A DSN value from Sentry",
+      "required": false
+    },
     "DEFAULT_TIMEOUT": "300",
     "LOG_LEVEL": "INFO",
     "SSH_PRIVATE_KEY": {

--- a/app.json
+++ b/app.json
@@ -2,6 +2,7 @@
   "name": "Freight",
   "description": "A deploy service.",
   "repository": "https://github.com/getsentry/freight",
+  "logo": "https://raw.githubusercontent.com/getsentry/freight/master/static/img/freight-logo.png",
   "keywords": ["deploy"],
   "env": {
     "BUILDPACK_URL": "https://github.com/heroku/heroku-buildpack-multi.git",

--- a/app.json
+++ b/app.json
@@ -46,12 +46,12 @@
     {
       "process": "web",
       "quantity": 1,
-      "size": "1X"
+      "size": "free"
     },
     {
       "process": "worker",
       "quantity": 1,
-      "size": "1X"
+      "size": "free"
     }
   ],
   "addons": [

--- a/app.json
+++ b/app.json
@@ -39,6 +39,9 @@
       "description": "A private key to use when cloning repositories"
     }
   },
+  "buildpacks": [
+    {"url": "https://github.com/heroku/heroku-buildpack-multi.git"}
+  ],
   "formation": [
     {
       "process": "web",


### PR DESCRIPTION
The main fix here is changing the dyno names from the old `"1X"` `"free"` (as this was causing deploy on heroku to fail).

While I was at it, I also added configuration for the logo and some missing configuration variables (the github token, most importantly).

~~I'm running a deployment right now, just to double-check that everything is fine.~~ deploy using this configuration was fine.

BTW, let me know if you want me to squash commits into one, as it's a small enough change.

Cheers