### PR TITLE
Custom task name + targeting specific ref

### DIFF
--- a/freight/api/task_index.py
+++ b/freight/api/task_index.py
@@ -17,39 +17,19 @@ from freight.utils.workspace import Workspace
 
 
 class TaskIndexApiView(ApiView):
-    def _get_current_sha(self, app, env):
-        return db.session.query(
-            Task.sha,
-        ).filter(
-            Task.app_id == app.id,
-            Task.environment == env,
-            Task.status == TaskStatus.finished,
-        ).order_by(
-            Task.number.desc(),
-        ).limit(1).scalar()
-
-    def _get_previous_sha(self, app, env, current_sha):
-        return db.session.query(
-            Task.sha,
-        ).filter(
-            Task.app_id == app.id,
-            Task.environment == env,
-            Task.status == TaskStatus.finished,
-            Task.sha != current_sha,
-        ).order_by(
-            Task.number.desc(),
-        ).limit(1).scalar()
-
     def _get_internal_ref(self, app, env, ref):
         # find the most recent green build for this app
         if ref == ':current':
-            return self._get_current_sha(app, env)
+            return app.get_current_sha(env)
+
         # the previous stable ref (before current)
-        elif ref == ':previous':
-            current_sha = self._get_current_sha(app, env)
+        if ref == ':previous':
+            current_sha = app.get_current_sha(env)
+
             if not current_sha:
                 return
-            return self._get_previous_sha(app, env, current_sha)
+
+            return app.get_previous_sha(env, current_sha=current_sha)
         raise ValueError('Unknown ref: {}'.format(ref))
 
     get_parser = reqparse.RequestParser()

--- a/freight/vcs/git.py
+++ b/freight/vcs/git.py
@@ -76,7 +76,7 @@ class GitVcs(Vcs):
         if shas:
             return shas[0]
 
-        shas = self.run(['show-ref', '--hash=0', ref],
+        shas = self.run(['show-ref', '--hash=0'],
                         capture=True).split('\n')
 
         if ref in shas:

--- a/freight/vcs/git.py
+++ b/freight/vcs/git.py
@@ -70,16 +70,17 @@ class GitVcs(Vcs):
                         capture=True)
 
     def get_sha(self, ref):
-        shas = self.run(['show-ref', '--hash=0', ref],
-                        capture=True).split('\n')
+        try:
+            shas = self.run(['show-ref', '--hash=0', ref],
+                            capture=True).split('\n')
 
-        if shas:
-            return shas[0]
+            if shas:
+                return shas[0]
+        except CommandError:
+            shas = self.run(['show-ref', '--hash=0'],
+                            capture=True).split('\n')
 
-        shas = self.run(['show-ref', '--hash=0'],
-                        capture=True).split('\n')
-
-        if ref in shas:
-            return ref
+            if ref in shas:
+                return ref
 
         return None

--- a/freight/vcs/git.py
+++ b/freight/vcs/git.py
@@ -73,3 +73,7 @@ class GitVcs(Vcs):
         shas = self.run(['show-ref', '--hash=0', ref],
                         capture=True).split('\n')
         return shas[0]
+
+    def is_sha_exists(self, sha):
+        return sha in self.run(['show-ref', '--hash=0'],
+                               capture=True).split('\n')

--- a/freight/vcs/git.py
+++ b/freight/vcs/git.py
@@ -72,8 +72,14 @@ class GitVcs(Vcs):
     def get_sha(self, ref):
         shas = self.run(['show-ref', '--hash=0', ref],
                         capture=True).split('\n')
-        return shas[0]
 
-    def is_sha_exists(self, sha):
-        return sha in self.run(['show-ref', '--hash=0'],
-                               capture=True).split('\n')
+        if shas:
+            return shas[0]
+
+        shas = self.run(['show-ref', '--hash=0', ref],
+                        capture=True).split('\n')
+
+        if ref in shas:
+            return ref
+
+        return None

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,8 @@
+flake8>=2.1.0,<2.2.0
+mock>=1.0.1,<1.1.0
+loremipsum>=1.0.5,<1.1.0
+pytest>=2.5.0,<2.6.0
+pytest-cov>=1.6,<1.7
+pytest-timeout>=0.3,<0.4
+pytest-xdist>=1.9,<1.10
+responses>=0.3.0,<0.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,16 @@
+alembic>=0.7.4,<0.8.0
+blessings>=1.6.0,<1.7.0
+blinker>=1.3.0,<1.4.0
+celery>=3.1.18,<3.2.0
+flask>=0.10.1,<0.11.0
+flask-heroku>=0.1.9,<0.2.0
+flask-sslify>=0.1.4,<0.2.0
+flask-sqlalchemy>=1.0,<1.1
+flask-redis>=0.0.6,<0.1.0
+flask-restful>=0.3.1,<0.4.0
+oauth2client>=1.2,<1.3
+psycopg2>=2.5.1,<2.6.0
+raven>=5.1.1,<5.2.0
+redis>=2.10.3,<2.11.0
+requests>=2.5.1,<2.6.0
+uwsgi>=2.0.9,<2.1.0

--- a/setup.py
+++ b/setup.py
@@ -27,36 +27,11 @@ for m in ('multiprocessing', 'billiard'):
 
 ROOT = os.path.realpath(os.path.join(os.path.dirname(__file__)))
 
-tests_require = [
-    'flake8>=2.1.0,<2.2.0',
-    'mock>=1.0.1,<1.1.0',
-    'loremipsum>=1.0.5,<1.1.0',
-    'pytest>=2.5.0,<2.6.0',
-    'pytest-cov>=1.6,<1.7',
-    'pytest-timeout>=0.3,<0.4',
-    'pytest-xdist>=1.9,<1.10',
-    'responses>=0.3.0,<0.4.0',
-]
+with open('requirements-test.txt') as file:
+    tests_require = file.read().splitlines()
 
-
-install_requires = [
-    'alembic>=0.7.4,<0.8.0',
-    'blessings>=1.6.0,<1.7.0',
-    'blinker>=1.3.0,<1.4.0',
-    'celery>=3.1.18,<3.2.0',
-    'flask>=0.10.1,<0.11.0',
-    'flask-heroku>=0.1.9,<0.2.0',
-    'flask-sslify>=0.1.4,<0.2.0',
-    'flask-sqlalchemy>=1.0,<1.1',
-    'flask-redis>=0.0.6,<0.1.0',
-    'flask-restful>=0.3.1,<0.4.0',
-    'oauth2client>=1.2,<1.3',
-    'psycopg2>=2.5.1,<2.6.0',
-    'raven>=5.1.1,<5.2.0',
-    'redis>=2.10.3,<2.11.0',
-    'requests>=2.5.1,<2.6.0',
-    'uwsgi>=2.0.9,<2.1.0',
-]
+with open('requirements.txt') as file:
+    install_requires = file.read().splitlines()
 
 setup(
     name='freight',

--- a/tests/api/test_controller.py
+++ b/tests/api/test_controller.py
@@ -10,4 +10,4 @@ class CatchallTest(TestCase):
         for method in ('get', 'post', 'put', 'delete', 'patch'):
             resp = getattr(self.client, method)(path)
             assert resp.status_code == 404
-            assert resp.data == '{"error": "Not Found"}'
+            assert ''.join(resp.data.splitlines()) == '{"error": "Not Found"}'

--- a/tests/vcs/test_git.py
+++ b/tests/vcs/test_git.py
@@ -2,11 +2,8 @@ from __future__ import absolute_import
 
 from subprocess import check_call
 
-import pytest
-
 from freight.testutils import TestCase
 from freight.utils.workspace import Workspace
-from freight.vcs.base import CommandError
 from freight.vcs.git import GitVcs
 
 
@@ -66,11 +63,23 @@ class GitVcsTest(TestCase):
         vcs.clone()
         vcs.update()
         sha = vcs.get_sha('master')
+
+        assert len(sha) == 40
+
+    def test_get_sha_with_specific_sha(self):
+        vcs = self.get_vcs()
+        vcs.clone()
+        vcs.update()
+
+        shas = vcs.run(['show-ref', '--hash=0'],
+                       capture=True).split('\n')
+
+        sha = vcs.get_sha(shas[0])
+
         assert len(sha) == 40
 
     def test_invalid_ref(self):
         vcs = self.get_vcs()
         vcs.clone()
         vcs.update()
-        with pytest.raises(CommandError):
-            vcs.get_sha('foo')
+        assert vcs.get_sha('foo') is None


### PR DESCRIPTION
Hello,

This PR adds the following features:

* A ``name`` parameter can be added when the task is created to override the default ``deploy`` task name
* The ``ref`` parameter can target a specific sha to checkout, we can still use ``:current``, ``:previous`` and the branch name
* Export requirements to specific files to make life easier when you are developing
* ``get_current_sha`` and ``get_previous_sha`` methods have been exported to the app model
* More unittests :tada: 

If you want more information, I'm available.