### PR TITLE
Git describe fails with annotated tags

### DIFF
--- a/tests/vcs/test_git.py
+++ b/tests/vcs/test_git.py
@@ -67,19 +67,15 @@ class GitVcsTest(TestCase):
         check_call('cd %s && git tag -a v1 -m "v1"' % (
             self.remote_path,
         ), shell=True)
-        check_call('cd %s && touch BAZ && git add BAZ && git commit -m "test\nbaz\n"' % (
-            self.remote_path,
-        ), shell=True)
 
-        check_call('cd %s && git checkout -b foo' % (
-            self.remote_path,
-        ), shell=True)
-        check_call('cd %s && touch BUZZ && git add BUZZ && git commit -m "test\nbuzz\n"' % (
+        vcs.update()
+        master_sha = vcs.describe('master')
+        assert master_sha == 'v1'
+
+        check_call('cd %s && touch BAZ && git add BAZ && git commit -m "test\nbaz\n"' % (
             self.remote_path,
         ), shell=True)
 
         vcs.update()
         master_sha = vcs.describe('master')
-        branch_sha = vcs.describe('foo')
-
-        assert branch_sha != master_sha
+        assert master_sha != 'v1'

--- a/tests/vcs/test_git.py
+++ b/tests/vcs/test_git.py
@@ -57,3 +57,29 @@ class GitVcsTest(TestCase):
         vcs.update()
         sha = vcs.describe('master')
         assert len(sha) == 40
+
+    def test_describe_branch(self):
+        vcs = self.get_vcs()
+        vcs.clone()
+        vcs.update()
+
+        # create annotated tag
+        check_call('cd %s && git tag -a v1 -m "v1"' % (
+            self.remote_path,
+        ), shell=True)
+        check_call('cd %s && touch BAZ && git add BAZ && git commit -m "test\nbaz\n"' % (
+            self.remote_path,
+        ), shell=True)
+
+        check_call('cd %s && git checkout -b foo' % (
+            self.remote_path,
+        ), shell=True)
+        check_call('cd %s && touch BUZZ && git add BUZZ && git commit -m "test\nbuzz\n"' % (
+            self.remote_path,
+        ), shell=True)
+
+        vcs.update()
+        master_sha = vcs.describe('master')
+        branch_sha = vcs.describe('foo')
+
+        assert branch_sha != master_sha


### PR DESCRIPTION
Follow up for https://github.com/getsentry/freight/commit/3009356d88b21b0b979a02c41d129f80b68743a2 - I've created a failing test for using `git describe` to get the correct sha in a repository with annotated tags. Any suggestions on how to fix this? 