### PR TITLE
Improve consistency around task state and notifications

### DIFF
--- a/freight/notifiers/queue.py
+++ b/freight/notifiers/queue.py
@@ -34,6 +34,15 @@ class NotificationQueue(object):
         })
         pipe.execute()
 
+    def remove(self, task, type):
+        key = '{}:data:{}:{}'.format(self.prefix, type, task.id)
+        pipe = self.conn.pipeline()
+        # the score represents the time enqueued, thus the debounce time
+        # can be controlled after the fact
+        pipe.zrem('{}:queue'.format(self.prefix), key)
+        pipe.rem(key)
+        pipe.execute()
+
     def get(self):
         """
         Fetches and removes a due item from the queue.

--- a/freight/notifiers/utils.py
+++ b/freight/notifiers/utils.py
@@ -67,3 +67,11 @@ def send_task_notifications(task, event):
                 config=data['config'],
                 event=event,
             )
+
+
+def clear_task_notifications(task):
+    for data in task.notifiers:
+        queue.remove(
+            task=task,
+            type=data['type'],
+        )


### PR DESCRIPTION
This could be improved further by abstracting task updates so they always lock in these situations, but it at least helps the situation where we are mutating the task status vs the execute wrapper reacting from it.