### PR TITLE
Wrap shell execution in bash -c

### DIFF
--- a/freight/providers/shell.py
+++ b/freight/providers/shell.py
@@ -31,4 +31,4 @@ class ShellProvider(Provider):
             task=task,
             ssh_key=ssh_key.name if ssh_key else '~/.ssh/id_rsa',
         )
-        return workspace.run(command, env=task.provider_config.get('env'))
+        return workspace.run(['bash', '-c', command], env=task.provider_config.get('env'))


### PR DESCRIPTION
This allows more complex "commands" to be executed, and things with &&
or ;, etc. Without this, we rely on shlex.split() to do the right thing.