### PR TITLE
Refactor Task model to be a 1-to-1 with Deploy

### DIFF
--- a/freight/api/deploy_index.py
+++ b/freight/api/deploy_index.py
@@ -10,7 +10,7 @@ from freight.api.serializer import serialize
 from freight.config import db, redis
 from freight.exceptions import CheckError, CheckPending
 from freight.models import (
-    App, Repository, Task, TaskSequence, TaskStatus, User
+    App, Repository, Task, Deploy, DeploySequence, TaskStatus, User
 )
 from freight.notifiers import NotifierEvent
 from freight.notifiers.utils import send_task_notifications
@@ -19,9 +19,9 @@ from freight.utils.redis import lock
 from freight.utils.workspace import Workspace
 
 
-class TaskIndexApiView(ApiView):
+class DeployIndexApiView(ApiView):
     def _get_internal_ref(self, app, env, ref):
-        # find the most recent green build for this app
+        # find the most recent green deploy for this app
         if ref == ':current':
             return app.get_current_sha(env)
 
@@ -44,7 +44,7 @@ class TaskIndexApiView(ApiView):
 
     def get(self):
         """
-        Retrieve a list of tasks.
+        Retrieve a list of deploys.
 
         If any parameters are invalid the result will simply be an empty list.
         """
@@ -56,7 +56,7 @@ class TaskIndexApiView(ApiView):
             app = App.query.filter(App.name == args.app).first()
             if not app:
                 return self.respond([])
-            qs_filters.append(Task.app_id == app.id)
+            qs_filters.append(Deploy.app_id == app.id)
 
         if args.user:
             user = User.query.filter(User.name == args.user).first()
@@ -65,7 +65,7 @@ class TaskIndexApiView(ApiView):
             qs_filters.append(Task.user_id == user.id)
 
         if args.env:
-            qs_filters.append(Task.environment == args.env)
+            qs_filters.append(Deploy.environment == args.env)
 
         if args.ref:
             qs_filters.append(Task.ref == args.ref)
@@ -74,9 +74,9 @@ class TaskIndexApiView(ApiView):
             status_list = map(TaskStatus.label_to_id, args.status)
             qs_filters.append(Task.status.in_(status_list))
 
-        task_qs = Task.query.filter(*qs_filters).order_by(Task.id.desc())
+        deploy_qs = Deploy.query.filter(*qs_filters).order_by(Deploy.id.desc())
 
-        return self.paginate(task_qs, on_results=serialize)
+        return self.paginate(deploy_qs, on_results=serialize)
 
     post_parser = reqparse.RequestParser()
     post_parser.add_argument('app', required=True)
@@ -161,11 +161,9 @@ class TaskIndexApiView(ApiView):
                         name='check_failed',
                     )
 
-        with lock(redis, 'task:create:{}'.format(app.id), timeout=5):
+        with lock(redis, 'deploy:create:{}'.format(app.id), timeout=5):
             task = Task(
                 app_id=app.id,
-                environment=args.env,
-                number=TaskSequence.get_clause(app.id, args.env),
                 # TODO(dcramer): ref should default based on app config
                 ref=ref,
                 sha=sha,
@@ -181,8 +179,18 @@ class TaskIndexApiView(ApiView):
                 },
             )
             db.session.add(task)
+            db.session.flush()
+            db.session.refresh(task)
+
+            deploy = Deploy(
+                task_id=task.id,
+                app_id=app.id,
+                environment=args.env,
+                number=DeploySequence.get_clause(app.id, args.env),
+            )
+            db.session.add(deploy)
             db.session.commit()
 
             send_task_notifications(task, NotifierEvent.TASK_QUEUED)
 
-        return self.respond(serialize(task), status_code=201)
+        return self.respond(serialize(deploy), status_code=201)

--- a/freight/api/deploy_log.py
+++ b/freight/api/deploy_log.py
@@ -6,34 +6,34 @@ from freight.api.base import ApiView
 from freight.config import db
 from freight.models import LogChunk
 
-from .task_details import TaskMixin
+from .deploy_details import DeployMixin
 
 
-class TaskLogApiView(ApiView, TaskMixin):
+class DeployLogApiView(ApiView, DeployMixin):
     get_parser = reqparse.RequestParser()
     get_parser.add_argument('offset', location='args', type=int, default=0)
     get_parser.add_argument('limit', location='args', type=int)
 
     def get(self, **kwargs):
         """
-        Retrieve task log.
+        Retrieve deploy log.
         """
-        task = self._get_task(**kwargs)
-        if task is None:
-            return self.error('Invalid task', name='invalid_resource', status_code=404)
+        deploy = self._get_deploy(**kwargs)
+        if deploy is None:
+            return self.error('Invalid deploy', name='invalid_resource', status_code=404)
 
         args = self.get_parser.parse_args()
 
         queryset = db.session.query(
             LogChunk.text, LogChunk.offset, LogChunk.size
         ).filter(
-            LogChunk.task_id == task.id,
+            LogChunk.task_id == deploy.task_id,
         ).order_by(LogChunk.offset.asc())
 
         if args.offset == -1:
             # starting from the end so we need to know total size
             tail = db.session.query(LogChunk.offset + LogChunk.size).filter(
-                LogChunk.task_id == task.id,
+                LogChunk.task_id == deploy.task_id,
             ).order_by(LogChunk.offset.desc()).limit(1).scalar()
 
             if tail is None:

--- a/freight/api/serializer/__init__.py
+++ b/freight/api/serializer/__init__.py
@@ -5,5 +5,5 @@ from .manager import serialize  # NOQA
 # TODO(dcramer): we cant seem to use import_submodules here as something is
 # wrong w/ the code that causes it to mess up the default_manager instance
 from . import app  # NOQA
-from . import task  # NOQA
+from . import deploy  # NOQA
 from . import user  # NOQA

--- a/freight/api/serializer/deploy.py
+++ b/freight/api/serializer/deploy.py
@@ -52,6 +52,7 @@ class DeploySerializer(Serializer):
 
             attrs[item] = {
                 'app': apps[item.app_id],
+                'task': tasks[item.task_id],
                 'user': user_map.get(tasks[item.task_id].user_id),
                 'estimatedDuration': estimatedDuration,
             }
@@ -59,8 +60,7 @@ class DeploySerializer(Serializer):
 
     def serialize(self, item, attrs):
         app = attrs['app']
-
-        task = Task.query.filter(Task.id == item.task_id).first()
+        task = attrs['task']
 
         return {
             'id': str(item.id),

--- a/freight/config.py
+++ b/freight/config.py
@@ -165,6 +165,8 @@ def configure_api(app):
     api.add_resource(AppIndexApiView, '/apps/')
     api.add_resource(AppDetailsApiView, '/apps/<app>/')
     api.add_resource(StatsApiView, '/stats/')
+    api.add_resource(DeployIndexApiView, '/tasks/',
+                     endpoint='deploy-index-deprecated')
     api.add_resource(DeployIndexApiView, '/deploys/')
 
     # old style
@@ -172,6 +174,10 @@ def configure_api(app):
     api.add_resource(DeployLogApiView, '/deploys/<deploy_id>/log/')
 
     # new style
+    api.add_resource(DeployDetailsApiView, '/tasks/<app>/<env>/<number>/',
+                     endpoint='deploy-details-deprecated')
+    api.add_resource(DeployLogApiView, '/tasks/<app>/<env>/<number>/log/',
+                     endpoint='deploy-log-deprecated')
     api.add_resource(DeployDetailsApiView, '/deploys/<app>/<env>/<number>/',
                      endpoint='deploy-details')
     api.add_resource(DeployLogApiView, '/deploys/<app>/<env>/<number>/log/',

--- a/freight/config.py
+++ b/freight/config.py
@@ -158,24 +158,24 @@ def configure_api(app):
     from freight.api.app_details import AppDetailsApiView
     from freight.api.app_index import AppIndexApiView
     from freight.api.stats import StatsApiView
-    from freight.api.task_details import TaskDetailsApiView
-    from freight.api.task_index import TaskIndexApiView
-    from freight.api.task_log import TaskLogApiView
+    from freight.api.deploy_details import DeployDetailsApiView
+    from freight.api.deploy_index import DeployIndexApiView
+    from freight.api.deploy_log import DeployLogApiView
 
     api.add_resource(AppIndexApiView, '/apps/')
     api.add_resource(AppDetailsApiView, '/apps/<app>/')
     api.add_resource(StatsApiView, '/stats/')
-    api.add_resource(TaskIndexApiView, '/tasks/')
+    api.add_resource(DeployIndexApiView, '/deploys/')
 
     # old style
-    api.add_resource(TaskDetailsApiView, '/tasks/<task_id>/')
-    api.add_resource(TaskLogApiView, '/tasks/<task_id>/log/')
+    api.add_resource(DeployDetailsApiView, '/deploys/<deploy_id>/')
+    api.add_resource(DeployLogApiView, '/deploys/<deploy_id>/log/')
 
     # new style
-    api.add_resource(TaskDetailsApiView, '/tasks/<app>/<env>/<number>/',
-                     endpoint='task-details')
-    api.add_resource(TaskLogApiView, '/tasks/<app>/<env>/<number>/log/',
-                     endpoint='task-log')
+    api.add_resource(DeployDetailsApiView, '/deploys/<app>/<env>/<number>/',
+                     endpoint='deploy-details')
+    api.add_resource(DeployLogApiView, '/deploys/<app>/<env>/<number>/log/',
+                     endpoint='deploy-log')
 
     # catchall should be the last resource
     api.add_resource(ApiCatchall, '/<path:path>')

--- a/freight/models/app.py
+++ b/freight/models/app.py
@@ -84,20 +84,20 @@ class App(db.Model):
         return data.get('default_ref', DEFAULT_REF)
 
     def get_current_sha(self, env):
-        from freight.models import Task, TaskStatus
+        from freight.models import Task, Deploy, TaskStatus
 
         return db.session.query(
             Task.sha,
         ).filter(
             Task.app_id == self.id,
-            Task.environment == env,
+            Deploy.environment == env,
             Task.status == TaskStatus.finished,
         ).order_by(
-            Task.number.desc(),
+            Deploy.number.desc(),
         ).limit(1).scalar()
 
     def get_previous_sha(self, env, current_sha=None):
-        from freight.models import Task, TaskStatus
+        from freight.models import Task, Deploy, TaskStatus
 
         if current_sha is None:
             current_sha = self.get_current_sha(env)
@@ -109,9 +109,9 @@ class App(db.Model):
             Task.sha,
         ).filter(
             Task.app_id == self.id,
-            Task.environment == env,
+            Deploy.environment == env,
             Task.status == TaskStatus.finished,
             Task.sha != current_sha,
         ).order_by(
-            Task.number.desc(),
+            Deploy.number.desc(),
         ).limit(1).scalar()

--- a/freight/models/deploy.py
+++ b/freight/models/deploy.py
@@ -1,0 +1,23 @@
+from __future__ import absolute_import
+
+from sqlalchemy import Column, ForeignKey, Integer, String
+from sqlalchemy.schema import Index, UniqueConstraint
+
+from freight.config import db
+
+
+class Deploy(db.Model):
+    __tablename__ = 'deploy'
+    __table_args__ = (
+        Index('idx_deploy_task_id', 'task_id'),
+        Index('idx_deploy_app_id', 'app_id'),
+        UniqueConstraint('task_id', 'app_id', 'environment', 'number', name='unq_deploy_number'),
+    )
+
+    id = Column(Integer, primary_key=True)
+    task_id = Column(Integer, ForeignKey('task.id', ondelete='CASCADE'),
+                    nullable=False)
+    app_id = Column(Integer, ForeignKey('app.id', ondelete='CASCADE'),
+                    nullable=False)
+    environment = Column(String(64), nullable=False, default='production')
+    number = Column(Integer, nullable=False)

--- a/freight/models/deploysequence.py
+++ b/freight/models/deploysequence.py
@@ -6,8 +6,8 @@ from sqlalchemy.sql import func, select
 from freight.config import db
 
 
-class TaskSequence(db.Model):
-    __tablename__ = 'tasksequence'
+class DeploySequence(db.Model):
+    __tablename__ = 'deploysequence'
 
     app_id = Column(Integer, nullable=False, primary_key=True)
     environment = Column(String(64), nullable=False, primary_key=True)
@@ -16,4 +16,4 @@ class TaskSequence(db.Model):
 
     @classmethod
     def get_clause(self, app_id, environment):
-        return select([func.next_task_number(app_id, environment)])
+        return select([func.next_deploy_number(app_id, environment)])

--- a/freight/models/task.py
+++ b/freight/models/task.py
@@ -2,22 +2,10 @@ from __future__ import absolute_import
 
 from datetime import datetime
 from sqlalchemy import Column, DateTime, ForeignKey, Integer, String
-from sqlalchemy.schema import Index, UniqueConstraint
+from sqlalchemy.schema import Index
 
 from freight.config import db
 from freight.db.types.json import JSONEncodedDict
-
-
-class TaskName(object):
-    deploy = 'deploy'
-
-    @classmethod
-    def get_label(cls, status):
-        return status
-
-    @classmethod
-    def label_to_id(cls, label):
-        return getattr(cls, label)
 
 
 class TaskStatus(object):
@@ -55,18 +43,15 @@ class Task(db.Model):
     __table_args__ = (
         Index('idx_task_app_id', 'app_id'),
         Index('idx_task_user_id', 'user_id'),
-        UniqueConstraint('app_id', 'environment', 'number', name='unq_task_number'),
     )
 
     id = Column(Integer, primary_key=True)
     app_id = Column(Integer, ForeignKey('app.id', ondelete="CASCADE"),
                     nullable=False)
-    number = Column(Integer, nullable=False)
     user_id = Column(Integer, ForeignKey('user.id', ondelete="CASCADE"),
                      nullable=False)
     ref = Column(String(128), nullable=False)
     sha = Column(String(40))
-    environment = Column(String(64), nullable=False, default='production')
     provider = Column(String(64), nullable=False)
     status = Column(Integer, nullable=False)
     params = Column(JSONEncodedDict, nullable=True)

--- a/freight/notifiers/base.py
+++ b/freight/notifiers/base.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+from freight.models import Deploy
+
 __all__ = ['Notifier', 'NotifierEvent']
 
 
@@ -27,7 +29,18 @@ class Notifier(object):
         return {}
 
     def send(self, task, config, event):
+        # TODO(mattrobenolt): Split this out into send_deploy, send_x
+        # since we want different notifications for different tasks,
+        # and remove this shim. For now, we there are only deploys
+        deploy = Deploy.query.filter(Deploy.task_id == task.id).first()
+        return self.send_deploy(deploy, task, config, event)
+
+    def send_deploy(self, deploy, task, config, event):
         raise NotImplementedError
 
     def should_send(self, task, config, event):
+        deploy = Deploy.query.filter(Deploy.task_id == task.id).first()
+        return self.should_send_deploy(deploy, task, config, event)
+
+    def should_send_deploy(self, deploy, task, config, event):
         return event in config.get('events', self.DEFAULT_EVENTS)

--- a/freight/notifiers/sentry.py
+++ b/freight/notifiers/sentry.py
@@ -14,7 +14,7 @@ class SentryNotifier(Notifier):
             'webhook_url': {'required': True},
         }
 
-    def should_send(self, task, config, event):
+    def should_send_deploy(self, deploy, task, config, event):
         if event == NotifierEvent.TASK_STARTED:
             return True
 
@@ -23,23 +23,23 @@ class SentryNotifier(Notifier):
 
         return False
 
-    def send(self, task, config, event):
+    def send_deploy(self, deploy, task, config, event):
         webhook_url = config['webhook_url']
 
-        app = App.query.get(task.app_id)
+        app = App.query.get(deploy.app_id)
 
         payload = {
-            'number': task.number,
+            'number': deploy.number,
             'app_name': app.name,
             'params': dict(task.params or {}),
-            'env': task.environment,
+            'env': deploy.environment,
             'ref': task.ref,
             'sha': task.sha,
             'duration': task.duration,
             'event': 'started' if event == NotifierEvent.TASK_STARTED else 'finished',
             'dateStarted': task.date_started.isoformat() + 'Z' if task.date_started else None,
             'dateFinished': task.date_finished.isoformat() + 'Z' if task.date_finished else None,
-            'link': http.absolute_uri('/tasks/{}/{}/{}/'.format(app.name, task.environment, task.number)),
+            'link': http.absolute_uri('/deploys/{}/{}/{}/'.format(app.name, deploy.environment, deploy.number)),
         }
 
         http.post(webhook_url, json=payload)

--- a/freight/notifiers/slack.py
+++ b/freight/notifiers/slack.py
@@ -16,21 +16,21 @@ class SlackNotifier(Notifier):
             'webhook_url': {'required': True},
         }
 
-    def send(self, task, config, event):
+    def send_deploy(self, deploy, task, config, event):
         webhook_url = config['webhook_url']
 
-        app = App.query.get(task.app_id)
+        app = App.query.get(deploy.app_id)
 
         params = {
-            'number': task.number,
+            'number': deploy.number,
             'app_name': app.name,
             'params': dict(task.params or {}),
-            'env': task.environment,
+            'env': deploy.environment,
             'ref': task.ref,
             'sha': task.sha[:7] if task.sha else task.ref,
             'status_label': task.status_label,
             'duration': task.duration,
-            'link': http.absolute_uri('/{}/{}/{}'.format(app.name, task.environment, task.number)),
+            'link': http.absolute_uri('/deploys/{}/{}/{}'.format(app.name, deploy.environment, deploy.number)),
         }
 
         # TODO(dcramer): show the ref when it differs from the sha

--- a/freight/providers/shell.py
+++ b/freight/providers/shell.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 __all__ = ['ShellProvider']
 
 from .base import Provider
+from freight.models import Deploy
 
 
 class ShellProvider(Provider):
@@ -12,11 +13,11 @@ class ShellProvider(Provider):
             'env': {'required': False, 'type': dict},
         }
 
-    def get_command(self, task, ssh_key):
+    def get_command(self, deploy, task, ssh_key):
         params = task.params or {}
 
         return task.provider_config['command'].format(
-            environment=task.environment,
+            environment=deploy.environment,
             sha=task.sha,
             ref=task.ref,
             ssh_key=ssh_key,
@@ -24,10 +25,15 @@ class ShellProvider(Provider):
         )
 
     def execute(self, workspace, task):
+        deploy = Deploy.query.filter(Deploy.task_id == task.id).first()
+        return self.execute_deploy(workspace, deploy, task)
+
+    def execute_deploy(self, workspace, deploy, task):
         # keep ssh_key in scope to ensure it doesnt get wiped until run() exits
         ssh_key = self.get_ssh_key()
 
         command = self.get_command(
+            deploy=deploy,
             task=task,
             ssh_key=ssh_key.name if ssh_key else '~/.ssh/id_rsa',
         )

--- a/freight/testutils/fixtures.py
+++ b/freight/testutils/fixtures.py
@@ -6,7 +6,7 @@ from uuid import uuid4
 
 from freight.config import db
 from freight.constants import PROJECT_ROOT
-from freight.models import App, Repository, Task, TaskSequence, TaskStatus, User
+from freight.models import App, Repository, Task, DeploySequence, Deploy, TaskStatus, User
 
 
 class Fixtures(object):
@@ -44,7 +44,6 @@ class Fixtures(object):
     def create_task(self, app, user, **kwargs):
         kwargs.setdefault('provider', 'shell')
         kwargs.setdefault('ref', 'master')
-        kwargs.setdefault('environment', 'production')
         kwargs.setdefault('sha', 'HEAD')
         kwargs.setdefault('status', TaskStatus.in_progress)
         kwargs.setdefault('data', {'provider_config': app.provider_config})
@@ -53,13 +52,26 @@ class Fixtures(object):
         task = Task(
             app_id=app.id,
             user_id=user.id,
-            number=TaskSequence.get_clause(app.id, kwargs['environment']),
             **kwargs
         )
         db.session.add(task)
         db.session.commit()
 
         return task
+
+    def create_deploy(self, task, app, **kwargs):
+        kwargs.setdefault('environment', 'production')
+
+        deploy = Deploy(
+            task_id=task.id,
+            app_id=app.id,
+            number=DeploySequence.get_clause(app.id, kwargs['environment']),
+            **kwargs
+        )
+        db.session.add(deploy)
+        db.session.commit()
+
+        return deploy
 
     def create_repo(self, **kwargs):
         kwargs.setdefault('url', PROJECT_ROOT)

--- a/migrations/versions/106230ad9e69_migrate_task_to_deploy.py
+++ b/migrations/versions/106230ad9e69_migrate_task_to_deploy.py
@@ -1,0 +1,128 @@
+"""
+migrate task to deploy
+
+Revision ID: 106230ad9e69
+Revises: 16c1b29dc47c
+Create Date: 2016-02-17 00:43:21.608658
+"""
+
+# revision identifiers, used by Alembic.
+revision = '106230ad9e69'
+down_revision = '16c1b29dc47c'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+MIGRATE_TASK_TO_DEPLOY = """
+INSERT INTO deploy (task_id, app_id, environment, number)
+SELECT id, app_id, environment, number FROM task
+"""
+
+MIGRATE_DEPLOY_TO_TASK = """
+UPDATE task
+SET number=deploy.number
+    environment=deploy.environment
+FROM deploy
+WHERE task.id=deploy.task_id
+"""
+
+NEXT_VALUE_FUNCTION = """
+CREATE OR REPLACE FUNCTION next_deploy_number(int, char) RETURNS int AS $$
+DECLARE
+  cur_app_id ALIAS FOR $1;
+  cur_env ALIAS FOR $2;
+  next_value int;
+BEGIN
+  LOOP
+    UPDATE deploysequence SET value = value + 1
+    WHERE app_id = cur_app_id AND environment = cur_env
+    RETURNING value INTO next_value;
+    IF FOUND THEN
+      RETURN next_value;
+    END IF;
+
+    BEGIN
+        INSERT INTO deploysequence (app_id, environment, value)
+        VALUES (cur_app_id, cur_env, 1)
+        RETURNING value INTO next_value;
+        RETURN next_value;
+    EXCEPTION WHEN unique_violation THEN
+        -- do nothing
+    END;
+  END LOOP;
+END;
+$$ LANGUAGE plpgsql
+"""
+
+
+def upgrade():
+    op.create_table(
+        'deploy',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('task_id', sa.Integer(), nullable=False),
+        sa.Column('app_id', sa.Integer(), nullable=False),
+        sa.Column('environment', sa.String(64), nullable=False),
+        sa.Column('number', sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(['task_id'], ['task.id'], ondelete='CASCADE'),
+        sa.ForeignKeyConstraint(['app_id'], ['app.id'], ondelete='CASCADE'),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('task_id', 'app_id', 'environment', 'number', name='unq_deploy_number')
+    )
+    op.create_index('idx_deploy_task_id', 'deploy', ['task_id'], unique=False)
+    op.create_index('idx_deploy_app_id', 'deploy', ['app_id'], unique=False)
+
+    # Migrate the data from Task to Deploy table
+    op.execute(MIGRATE_TASK_TO_DEPLOY)
+    op.execute('ALTER TABLE tasksequence RENAME TO deploysequence')
+    op.execute(NEXT_VALUE_FUNCTION)
+
+    op.drop_constraint(u'unq_task_number', 'task', type_='unique')
+    op.drop_column(u'task', 'environment')
+    op.drop_column(u'task', 'number')
+
+    op.execute('DROP FUNCTION IF EXISTS next_task_number(int, char)')
+
+
+def downgrade():
+    # Add back Task.number, as nullable
+    op.add_column(u'task', sa.Column('number', sa.INTEGER(), autoincrement=False, nullable=True))
+
+    # Migrate data from Deploy table back
+    op.execute(MIGRATE_DEPLOY_TO_TASK)
+
+    # Make column not nullable
+    op.alter_column(u'task', sa.Column('number', sa.INTEGER(), autoincrement=False, nullable=False))
+    op.create_unique_constraint(u'unq_task_number', 'task', ['app_id', 'environment', 'number'])
+
+    op.drop_index('idx_deploy_task_id', table_name='deploy')
+    op.drop_index('idx_deploy_app_id', table_name='deploy')
+    op.drop_table('deploy')
+
+    op.execute('ALTER TABLE deploysequence RENAME TO tasksequence')
+    op.execute("""
+CREATE OR REPLACE FUNCTION next_task_number(int, char) RETURNS int AS $$
+DECLARE
+  cur_app_id ALIAS FOR $1;
+  cur_env ALIAS FOR $2;
+  next_value int;
+BEGIN
+  LOOP
+    UPDATE tasksequence SET value = value + 1
+    WHERE app_id = cur_app_id AND environment = cur_env
+    RETURNING value INTO next_value;
+    IF FOUND THEN
+      RETURN next_value;
+    END IF;
+
+    BEGIN
+        INSERT INTO tasksequence (app_id, environment, value)
+        VALUES (cur_app_id, cur_env, 1)
+        RETURNING value INTO next_value;
+        RETURN next_value;
+    EXCEPTION WHEN unique_violation THEN
+        -- do nothing
+    END;
+  END LOOP;
+END;
+$$ LANGUAGE plpgsql""")

--- a/static/components/CreateDeploy.jsx
+++ b/static/components/CreateDeploy.jsx
@@ -68,7 +68,7 @@ var CreateDeploy = React.createClass({
     this.setState({
       submitInProgress: true,
     }, () => {
-      api.request('/tasks/', {
+      api.request('/deploys/', {
         method: 'POST',
         data: {
           app: this.state.app,
@@ -76,7 +76,7 @@ var CreateDeploy = React.createClass({
           ref: this.state.ref
         },
         success: (data) => {
-          this.gotoTask(data);
+          this.gotoDeploy(data);
         },
         error: (response) => {
           this.setState({
@@ -88,11 +88,11 @@ var CreateDeploy = React.createClass({
     });
   },
 
-  gotoTask(task) {
-    this.transitionTo('taskDetails', {
-      app: task.app.name,
-      env: task.environment,
-      number: task.number
+  gotoDeploy(deploy) {
+    this.transitionTo('deployDetails', {
+      app: deploy.app.name,
+      env: deploy.environment,
+      number: deploy.number
     });
   },
 

--- a/static/components/Overview.jsx
+++ b/static/components/Overview.jsx
@@ -16,7 +16,7 @@ var Overview = React.createClass({
 
   getInitialState() {
     return {
-      tasks: null,
+      deploys: null,
     };
   },
 
@@ -24,53 +24,53 @@ var Overview = React.createClass({
     api.request(this.getPollingUrl(), {
       success: (data) => {
         this.setState({
-          tasks: data
+          deploys: data
         });
       }
     });
   },
 
   getPollingUrl() {
-    return '/tasks/';
+    return '/deploys/';
   },
 
   pollingReceiveData(data) {
     this.setState({
-      tasks: data
+      deploys: data
     });
   },
 
-  taskInProgress(task) {
-    return task.status == 'in_progress';
+  deployInProgress(deploy) {
+    return deploy.status == 'in_progress';
   },
 
-  taskPending(task) {
-    return task.status == 'pending';
+  deployPending(deploy) {
+    return deploy.status == 'pending';
   },
 
   render() {
-    if (this.state.tasks === null) {
+    if (this.state.deploys === null) {
       return (
         <div className="container" style={{textAlign: "center"}}>
           <LoadingIndicator>
-            <p>Loading list of tasks.</p>
+            <p>Loading list of deploys.</p>
           </LoadingIndicator>
         </div>
       );
     }
 
-    var activeTaskNodes = [];
-    var pendingTaskNodes = [];
-    var previousTaskNodes = [];
+    var activedeployNodes = [];
+    var pendingdeployNodes = [];
+    var previousdeployNodes = [];
 
-    this.state.tasks.forEach((task) => {
-      var node = <TaskSummary key={task.id} task={task} />;
-      if (this.taskInProgress(task)) {
-        activeTaskNodes.unshift(node);
-      } else if (this.taskPending(task)) {
-        pendingTaskNodes.unshift(node);
+    this.state.deploys.forEach((deploy) => {
+      var node = <TaskSummary key={deploy.id} task={deploy} />;
+      if (this.deployInProgress(deploy)) {
+        activedeployNodes.unshift(node);
+      } else if (this.deployPending(deploy)) {
+        pendingdeployNodes.unshift(node);
       } else {
-        previousTaskNodes.push(node);
+        previousdeployNodes.push(node);
       }
     });
 
@@ -80,13 +80,13 @@ var Overview = React.createClass({
           <div className="section-header">
             <h2>Active Deploys</h2>
           </div>
-          {(activeTaskNodes.length || pendingTaskNodes.length) ?
-            <div className="task-list">
-              {activeTaskNodes}
-              {pendingTaskNodes}
+          {(activedeployNodes.length || pendingdeployNodes.length) ?
+            <div className="deploy-list">
+              {activedeployNodes}
+              {pendingdeployNodes}
             </div>
           :
-            <p>There are no active tasks.</p>
+            <p>There are no active deploys.</p>
           }
         </div>
 
@@ -97,12 +97,12 @@ var Overview = React.createClass({
 
           <DeployChart />
 
-          {previousTaskNodes.length ?
-            <div className="task-list">
-              {previousTaskNodes}
+          {previousdeployNodes.length ?
+            <div className="deploy-list">
+              {previousdeployNodes}
             </div>
           :
-            <p>There are no historical tasks.</p>
+            <p>There are no historical deploys.</p>
           }
         </div>
       </div>

--- a/static/components/TaskDetails.jsx
+++ b/static/components/TaskDetails.jsx
@@ -104,7 +104,7 @@ var TaskDetails = React.createClass({
 
   getPollingUrl() {
     var params = this.getParams();
-    return '/tasks/' + params.app + '/' + params.env + '/' + params.number + '/';
+    return '/deploys/' + params.app + '/' + params.env + '/' + params.number + '/';
   },
 
   pollingReceiveData(data) {
@@ -156,7 +156,7 @@ var TaskDetails = React.createClass({
   pollLog() {
     var task = this.state.task;
 
-    var url = '/tasks/' + task.app.name + '/' + task.environment + '/' + task.number + '/log/?offset=' + this.state.logNextOffset;
+    var url = '/deploys/' + task.app.name + '/' + task.environment + '/' + task.number + '/log/?offset=' + this.state.logNextOffset;
 
     api.request(url, {
       success: (data) => {
@@ -185,7 +185,7 @@ var TaskDetails = React.createClass({
   cancelTask() {
     var task = this.state.task;
 
-    var url = '/tasks/' + task.app.name + '/' + task.environment + '/' + task.number + '/';
+    var url = '/deploys/' + task.app.name + '/' + task.environment + '/' + task.number + '/';
 
     api.request(url, {
       method: "PUT",
@@ -198,7 +198,7 @@ var TaskDetails = React.createClass({
         });
       },
       error: () => {
-        alert("Unable to cancel task.");
+        alert("Unable to cancel deploy.");
       }
     });
   },
@@ -223,7 +223,7 @@ var TaskDetails = React.createClass({
     }, () => {
       let task = this.state.task;
 
-      api.request('/tasks/', {
+      api.request('/deploys/', {
         method: 'POST',
         data: {
           app: task.app.name,
@@ -231,7 +231,7 @@ var TaskDetails = React.createClass({
           ref: task.sha,
         },
         success: (data) => {
-          this.transitionTo('taskDetails', {
+          this.transitionTo('deployDetails', {
             app: data.app.name,
             env: data.environment,
             number: data.number
@@ -273,7 +273,7 @@ var TaskDetails = React.createClass({
       liveScrollClassName += " btn-active";
     }
 
-    let className = 'task-details';
+    let className = 'deploy-details';
     if (inProgress) {
       className += ' active';
     } else {
@@ -287,7 +287,7 @@ var TaskDetails = React.createClass({
 
     return (
       <div className={className}>
-        <div className="task-log">
+        <div className="deploy-log">
           {this.state.logLoading ?
             <div style={{textAlign: "center"}}>
               <div className="loading" />
@@ -301,7 +301,7 @@ var TaskDetails = React.createClass({
           }
         </div>
 
-        <div className="task-header">
+        <div className="deploy-header">
           <div className="container">
             <h3>{task.name}</h3>
             <div className="ref">
@@ -324,9 +324,9 @@ var TaskDetails = React.createClass({
           </div>
         </div>
 
-        <div className="task-footer">
+        <div className="deploy-footer">
           <div className="container">
-            <div className="task-actions">
+            <div className="deploy-actions">
               {inProgress ?
                 <span>
                   <a className="btn btn-danger btn-sm"
@@ -344,7 +344,7 @@ var TaskDetails = React.createClass({
                    onClick={this.reDeploy}>Re-deploy</a>
               }
             </div>
-            <div className="task-progress">
+            <div className="deploy-progress">
               <Progress value={this.getEstimatedProgress(task)} />
             </div>
           </div>

--- a/static/components/TaskSummary.jsx
+++ b/static/components/TaskSummary.jsx
@@ -59,7 +59,7 @@ var TaskSummary = React.createClass({
       e.preventDefault();
     }
 
-    this.transitionTo('taskDetails', {
+    this.transitionTo('deployDetails', {
       app: this.props.task.app.name,
       env: this.props.task.environment,
       number: this.props.task.number
@@ -68,7 +68,7 @@ var TaskSummary = React.createClass({
 
   render() {
     var task = this.props.task;
-    var className = 'task';
+    var className = 'deploy';
     if (this.taskInProgress(task)) {
       className += ' active';
     } else {

--- a/static/less/base.less
+++ b/static/less/base.less
@@ -194,16 +194,16 @@ header {
   margin-bottom: 20px;
 }
 
-.task-list {
+.deploy-list {
     padding-left: 0;
     list-style: none;
 
-    > .task {
+    > .deploy {
       margin-bottom: 3px;
     }
 }
 
-.task {
+.deploy {
     .clearfix();
     padding: 15px;
     background: @lessDark;
@@ -272,11 +272,11 @@ header {
 }
 
 
-.task-details {
+.deploy-details {
   padding-top: 40px;
   padding-bottom: 30px;
 
-  .task-header {
+  .deploy-header {
     z-index: 1000;
     background: @lessDark;
     color: @light;
@@ -314,11 +314,11 @@ header {
     }
   }
 
-  &.finished .task-header .container {
+  &.finished .deploy-header .container {
     padding-left: 32px;
   }
 
-  &.finished .task-header .container h3:before {
+  &.finished .deploy-header .container h3:before {
     content: "";
     width: 8px;
     border-radius: 4px;
@@ -328,14 +328,14 @@ header {
     left: 15px;
     background: #3ED33E;
   }
-  &.cancelled .task-header .container h3:before {
+  &.cancelled .deploy-header .container h3:before {
     background-color: #7B7B7B;
   }
-  &.failed .task-header .container h3:before {
+  &.failed .deploy-header .container h3:before {
     background-color: #D33E3E;
   }
 
-  .task-footer {
+  .deploy-footer {
     z-index: 1000;
     background: @dark;
     color: @light;
@@ -351,11 +351,11 @@ header {
     }
   }
 
-  .task-actions {
+  .deploy-actions {
     float: right;
   }
 
-  .task-progress {
+  .deploy-progress {
     border: 1px solid @lessDark;
     border-radius: 4px;
     position: relative;
@@ -375,7 +375,7 @@ header {
   }
 
   &.finished {
-    .task-progress {
+    .deploy-progress {
       display: none;
     }
   }
@@ -393,7 +393,7 @@ header {
     }
   }
 
-  .task-log {
+  .deploy-log {
     padding: 5px;
 
     .line {

--- a/static/routes.jsx
+++ b/static/routes.jsx
@@ -17,7 +17,8 @@ var routes = (
     <Route path="/deploy" name="createDeploy" handler={CreateDeploy} />
     <Route path="/tasks/:app/:env/:number" name="taskDetailsLegacy" handler={TaskDetails} />
     <Route path="/:app/settings" name="appSettings" handler={AppSettings} />
-    <Route path="/:app/:env/:number" name="taskDetails" handler={TaskDetails} />
+    <Route path="/:app/:env/:number" name="deployDetailsLegancy" handler={TaskDetails} />
+    <Route path="/deploys/:app/:env/:number" name="deployDetails" handler={TaskDetails} />
     <Route path="/:app" name="appDetails" handler={AppDetails} />
     <Router.NotFoundRoute handler={RouteNotFound} />
   </Route>

--- a/static/routes.jsx
+++ b/static/routes.jsx
@@ -16,9 +16,9 @@ var routes = (
     <DefaultRoute name="overview" handler={Overview} />
     <Route path="/deploy" name="createDeploy" handler={CreateDeploy} />
     <Route path="/tasks/:app/:env/:number" name="taskDetailsLegacy" handler={TaskDetails} />
+    <Route path="/deploys/:app/:env/:number" name="deployDetails" handler={TaskDetails} />
     <Route path="/:app/settings" name="appSettings" handler={AppSettings} />
     <Route path="/:app/:env/:number" name="deployDetailsLegancy" handler={TaskDetails} />
-    <Route path="/deploys/:app/:env/:number" name="deployDetails" handler={TaskDetails} />
     <Route path="/:app" name="appDetails" handler={AppDetails} />
     <Router.NotFoundRoute handler={RouteNotFound} />
   </Route>

--- a/tests/api/serializer/test_deploy.py
+++ b/tests/api/serializer/test_deploy.py
@@ -5,19 +5,20 @@ from freight.models import TaskStatus
 from freight.testutils import TestCase
 
 
-class TaskSerializerTest(TestCase):
+class DeploySerializerTest(TestCase):
     def test_locked(self):
         user = self.create_user()
         repo = self.create_repo()
         app = self.create_app(repository=repo)
         task = self.create_task(app=app, user=user, status=TaskStatus.pending)
+        deploy = self.create_deploy(app=app, task=task)
 
-        result = serialize(task)
-        assert result['id'] == str(task.id)
+        result = serialize(deploy)
+        assert result['id'] == str(deploy.id)
         assert result['status'] == 'pending'
         assert result['ref'] == task.ref
         assert result['sha'] == task.sha
-        assert result['environment'] == task.environment
-        assert result['number'] == task.number
+        assert result['environment'] == deploy.environment
+        assert result['number'] == deploy.number
         assert result['app']['id'] == str(app.id)
         assert result['app']['name'] == app.name

--- a/tests/api/test_deploy_details.py
+++ b/tests/api/test_deploy_details.py
@@ -7,41 +7,42 @@ from freight.models import TaskStatus
 from freight.testutils import TestCase
 
 
-class TaskDetailsBase(TestCase):
+class DeployDetailsBase(TestCase):
     def setUp(self):
         self.user = self.create_user()
         self.repo = self.create_repo()
         self.app = self.create_app(repository=self.repo)
         self.task = self.create_task(app=self.app, user=self.user)
-        self.path = '/api/0/tasks/{}/'.format(self.task.id)
-        self.alt_path = '/api/0/tasks/{}/{}/{}/'.format(
+        self.deploy = self.create_deploy(app=self.app, task=self.task)
+        self.path = '/api/0/deploys/{}/'.format(self.deploy.id)
+        self.alt_path = '/api/0/deploys/{}/{}/{}/'.format(
             self.app.name,
-            self.task.environment,
-            self.task.number,
+            self.deploy.environment,
+            self.deploy.number,
         )
-        super(TaskDetailsBase, self).setUp()
+        super(DeployDetailsBase, self).setUp()
 
 
-class TaskDetailsTest(TaskDetailsBase):
+class DeployDetailsTest(DeployDetailsBase):
     def test_simple(self):
         resp = self.client.get(self.path)
         assert resp.status_code == 200
         data = json.loads(resp.data)
-        assert data['id'] == str(self.task.id)
+        assert data['id'] == str(self.deploy.id)
 
     def test_alt_path(self):
         resp = self.client.get(self.alt_path)
         assert resp.status_code == 200
         data = json.loads(resp.data)
-        assert data['id'] == str(self.task.id)
+        assert data['id'] == str(self.deploy.id)
 
 
-class TaskUpdateTest(TaskDetailsBase):
+class DeployUpdateTest(DeployDetailsBase):
     def test_simple(self):
         resp = self.client.put(self.path, data={'status': 'cancelled'})
         assert resp.status_code == 200
         data = json.loads(resp.data)
-        assert data['id'] == str(self.task.id)
+        assert data['id'] == str(self.deploy.id)
         db.session.expire(self.task)
         db.session.refresh(self.task)
         assert self.task.status == TaskStatus.cancelled
@@ -50,7 +51,7 @@ class TaskUpdateTest(TaskDetailsBase):
         resp = self.client.put(self.alt_path, data={'status': 'cancelled'})
         assert resp.status_code == 200
         data = json.loads(resp.data)
-        assert data['id'] == str(self.task.id)
+        assert data['id'] == str(self.deploy.id)
         db.session.expire(self.task)
         db.session.refresh(self.task)
         assert self.task.status == TaskStatus.cancelled

--- a/tests/api/test_deploy_log.py
+++ b/tests/api/test_deploy_log.py
@@ -7,17 +7,18 @@ from freight.models import LogChunk
 from freight.testutils import TestCase
 
 
-class TaskLogBase(TestCase):
+class DeployLogBase(TestCase):
     def setUp(self):
         self.user = self.create_user()
         self.repo = self.create_repo()
         self.app = self.create_app(repository=self.repo)
         self.task = self.create_task(app=self.app, user=self.user)
-        self.path = '/api/0/tasks/{}/log/'.format(self.task.id)
-        self.alt_path = '/api/0/tasks/{}/{}/{}/log/'.format(
+        self.deploy = self.create_deploy(app=self.app, task=self.task)
+        self.path = '/api/0/deploys/{}/log/'.format(self.deploy.id)
+        self.alt_path = '/api/0/deploys/{}/{}/{}/log/'.format(
             self.app.name,
-            self.task.environment,
-            self.task.number,
+            self.deploy.environment,
+            self.deploy.number,
         )
 
         offset = 0
@@ -31,10 +32,10 @@ class TaskLogBase(TestCase):
             offset += len(char)
         db.session.commit()
 
-        super(TaskLogBase, self).setUp()
+        super(DeployLogBase, self).setUp()
 
 
-class TaskLogTest(TaskLogBase):
+class DeployLogTest(DeployLogBase):
     def test_simple(self):
         resp = self.client.get(self.path)
         assert resp.status_code == 200

--- a/tests/notifiers/test_sentry.py
+++ b/tests/notifiers/test_sentry.py
@@ -20,6 +20,10 @@ class SentryNotifierBase(TestCase):
             user=self.user,
             status=TaskStatus.finished,
         )
+        self.deploy = self.create_deploy(
+            app=self.app,
+            task=self.task,
+        )
 
 
 class SentryNotifierTest(SentryNotifierBase):
@@ -29,7 +33,7 @@ class SentryNotifierTest(SentryNotifierBase):
 
         config = {'webhook_url': 'http://example.com/'}
 
-        self.notifier.send(self.task, config, NotifierEvent.TASK_FINISHED)
+        self.notifier.send_deploy(self.deploy, self.task, config, NotifierEvent.TASK_FINISHED)
 
         call = responses.calls[0]
         assert len(responses.calls) == 1
@@ -44,7 +48,7 @@ class SentryNotifierTest(SentryNotifierBase):
 
         config = {'webhook_url': 'http://example.com/'}
 
-        self.notifier.send(self.task, config, NotifierEvent.TASK_STARTED)
+        self.notifier.send_deploy(self.deploy, self.task, config, NotifierEvent.TASK_STARTED)
 
         call = responses.calls[0]
         assert len(responses.calls) == 1

--- a/tests/notifiers/test_slack.py
+++ b/tests/notifiers/test_slack.py
@@ -22,6 +22,10 @@ class SlackNotifierBase(TestCase):
             user=self.user,
             status=TaskStatus.finished,
         )
+        self.deploy = self.create_deploy(
+            app=self.app,
+            task=self.task,
+        )
 
 
 class SlackNotifierTest(SlackNotifierBase):
@@ -31,7 +35,7 @@ class SlackNotifierTest(SlackNotifierBase):
 
         config = {'webhook_url': 'http://example.com/'}
 
-        self.notifier.send(self.task, config, NotifierEvent.TASK_FINISHED)
+        self.notifier.send_deploy(self.deploy, self.task, config, NotifierEvent.TASK_FINISHED)
 
         call = responses.calls[0]
         assert len(responses.calls) == 1
@@ -47,7 +51,7 @@ class SlackNotifierTest(SlackNotifierBase):
 
         config = {'webhook_url': 'http://example.com/'}
 
-        self.notifier.send(self.task, config, NotifierEvent.TASK_STARTED)
+        self.notifier.send_deploy(self.deploy, self.task, config, NotifierEvent.TASK_STARTED)
 
         call = responses.calls[0]
         assert len(responses.calls) == 1

--- a/tests/providers/test_shell.py
+++ b/tests/providers/test_shell.py
@@ -15,6 +15,7 @@ class ShellProviderBase(TestCase):
         self.repo = self.create_repo()
         self.app = self.create_app(repository=self.repo)
         self.task = self.create_task(app=self.app, user=self.user)
+        self.deploy = self.create_deploy(app=self.app, task=self.task)
 
 
 class ShellProviderTest(ShellProviderBase):
@@ -22,8 +23,8 @@ class ShellProviderTest(ShellProviderBase):
         self.task.data['provider_config'] = {
             'command': 'env={environment} task={params[task]} ref={ref} sha={sha} ssh_key={ssh_key}'
         }
-        result = self.provider.get_command(self.task, 'id_rsa').split(' ')
-        assert 'env={}'.format(self.task.environment) in result
+        result = self.provider.get_command(self.deploy, self.task, 'id_rsa').split(' ')
+        assert 'env={}'.format(self.deploy.environment) in result
         assert 'ref={}'.format(self.task.ref) in result
         assert 'sha={}'.format(self.task.sha) in result
         assert 'task={}'.format(self.task.params['task']) in result

--- a/tests/tasks/test_check_queue.py
+++ b/tests/tasks/test_check_queue.py
@@ -16,11 +16,14 @@ class CheckQueueTestCase(TransactionTestCase):
         task = self.create_task(
             app=app, user=user, status=TaskStatus.pending,
         )
+        deploy = self.create_deploy(
+            app=app, task=task,
+        )
         db.session.commit()
 
         queue.apply('freight.jobs.check_queue')
 
-        mock_push.assert_called_once_with('freight.jobs.execute_task', [task.id])
+        mock_push.assert_called_once_with('freight.jobs.execute_deploy', [deploy.id])
 
     @patch.object(queue, 'push')
     def test_without_pending_task(self, mock_push):
@@ -29,6 +32,9 @@ class CheckQueueTestCase(TransactionTestCase):
         app = self.create_app(repository=repo)
         task = self.create_task(
             app=app, user=user, status=TaskStatus.in_progress,
+        )
+        deploy = self.create_deploy(
+            app=app, task=task,
         )
         db.session.commit()
 

--- a/tests/tasks/test_execute_task.py
+++ b/tests/tasks/test_execute_task.py
@@ -14,6 +14,7 @@ class ExecuteTaskTestCase(TransactionTestCase):
         repo = self.create_repo()
         app = self.create_app(repository=repo)
         task = self.create_task(app=app, user=user)
+        deploy = self.create_deploy(app=app, task=task)
         db.session.commit()
 
         workspace = Workspace(
@@ -31,7 +32,7 @@ class ExecuteTaskTestCase(TransactionTestCase):
         else:
             vcs_backend.clone()
 
-        queue.apply('freight.jobs.execute_task', kwargs={'task_id': task.id})
+        queue.apply('freight.jobs.execute_deploy', kwargs={'deploy_id': deploy.id})
 
         db.session.expire_all()
 


### PR DESCRIPTION
This paves the way to allow different types of tasks, each with their
own properties. Mostly to facilitate Builds next.

This allows Build + Deploy to leverage the same inner workings of Task
along with the LogChunk, without repeating ourselves too much.