### PR TITLE
Split TaskConfig off of App

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,3 @@
-web: bin/upgrade && PYTHONUNBUFFERED=1 bin/web --no-debug --addr=:${PORT}
+web: bin/upgrade && PYTHONUNBUFFERED=1 bin/web --addr=:${PORT} --debug
 worker: bin/upgrade && PYTHONUNBUFFERED=1 bin/worker --no-debug -n 4 -l ${LOG_LEVEL}
+static: node_modules/.bin/webpack -d --watch

--- a/freight/models/app.py
+++ b/freight/models/app.py
@@ -62,20 +62,16 @@ class App(db.Model):
     date_created = Column(DateTime, default=datetime.utcnow, nullable=False)
 
     @property
-    def checks(self):
-        return self.data.get('checks', [])
-
-    @property
-    def notifiers(self):
-        return self.data.get('notifiers', [])
-
-    @property
-    def provider_config(self):
-        return self.data.get('provider_config', {})
-
-    @property
     def environments(self):
         return self.data.get('environments', {})
+
+    @property
+    def deploy_config(self):
+        from freight.models import TaskConfig, TaskConfigType
+        return TaskConfig.query.filter(
+            TaskConfig.app_id == self.id,
+            TaskConfig.type == TaskConfigType.deploy,
+        ).first()
 
     def get_default_ref(self, env):
         data = self.environments.get(env)

--- a/freight/models/taskconfig.py
+++ b/freight/models/taskconfig.py
@@ -1,0 +1,63 @@
+from __future__ import absolute_import
+
+from sqlalchemy import Column, ForeignKey, Integer, String
+from sqlalchemy.schema import Index, UniqueConstraint
+
+from freight.config import db
+from freight.db.types.json import JSONEncodedDict
+
+
+class TaskConfigType(object):
+    deploy = 0
+
+    @classmethod
+    def get_label(cls, status):
+        return TYPE_LABELS[status]
+
+    @classmethod
+    def label_to_id(cls, label):
+        return TYPE_LABELS_REV[label]
+
+
+TYPE_LABELS = {
+    TaskConfigType.deploy: 'deploy',
+}
+TYPE_LABELS_REV = {
+    v: k for k, v in TYPE_LABELS.items()
+}
+
+
+class TaskConfig(db.Model):
+    __tablename__ = 'taskconfig'
+    __table_args__ = (
+        Index('idx_taskconfig_app_id', 'app_id'),
+        Index('idx_taskconfig_type', 'type'),
+        UniqueConstraint('app_id', 'type', name='unq_app_id_type'),
+    )
+
+    id = Column(Integer, primary_key=True)
+    app_id = Column(Integer, ForeignKey('app.id', ondelete="CASCADE"),
+                    nullable=False)
+    provider = Column(String(64), nullable=False)
+    type = Column(Integer)
+    data = Column(JSONEncodedDict)
+
+    @property
+    def checks(self):
+        return self.data.get('checks', [])
+
+    @property
+    def notifiers(self):
+        return self.data.get('notifiers', [])
+
+    @property
+    def provider_config(self):
+        return self.data.get('provider_config', {})
+
+    @property
+    def environments(self):
+        return self.data.get('environments', {})
+
+    @property
+    def type_label(self):
+        return TYPE_LABELS[self.type]

--- a/migrations/versions/205fd513c96_added_taskconfig.py
+++ b/migrations/versions/205fd513c96_added_taskconfig.py
@@ -1,0 +1,58 @@
+"""
+Added TaskConfig
+
+Revision ID: 205fd513c96
+Revises: 106230ad9e69
+Create Date: 2016-03-07 13:27:04.392376
+"""
+
+# revision identifiers, used by Alembic.
+revision = '205fd513c96'
+down_revision = '106230ad9e69'
+
+from alembic import op
+from sqlalchemy.sql import table
+import sqlalchemy as sa
+import freight
+
+
+def upgrade():
+    taskconfig_table = op.create_table(
+        'taskconfig',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('app_id', sa.Integer(), nullable=False),
+        sa.Column('provider', sa.String(length=64), nullable=False),
+        sa.Column('type', sa.Integer(), nullable=True),
+        sa.Column('data', freight.db.types.json.JSONEncodedDict(), nullable=True),
+        sa.ForeignKeyConstraint(['app_id'], ['app.id'], ondelete='CASCADE'),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('app_id', 'type', name='unq_app_id_type')
+    )
+    op.create_index('idx_taskconfig_app_id', 'taskconfig', ['app_id'], unique=False)
+    op.create_index('idx_taskconfig_type', 'taskconfig', ['type'], unique=False)
+
+    connection = op.get_bind()
+
+    app_table = table(
+        'app',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('provider', sa.String(length=54), nullable=False),
+        sa.Column('data', freight.db.types.json.JSONEncodedDict(), nullable=True)
+    )
+
+    # Copy over the existing configs out of the App table and into TaskConfigs
+    for app in connection.execute(app_table.select()):
+        print("Migrating App id=%s" % app.id)
+
+        op.bulk_insert(
+            taskconfig_table,
+            [
+                {'app_id': app.id, 'type': 0, 'provider': app.provider, 'data': app.data},
+            ],
+        )
+
+
+def downgrade():
+    op.drop_index('idx_taskconfig_type', table_name='taskconfig')
+    op.drop_index('idx_taskconfig_app_id', table_name='taskconfig')
+    op.drop_table('taskconfig')

--- a/tests/api/serializer/test_deploy.py
+++ b/tests/api/serializer/test_deploy.py
@@ -10,6 +10,7 @@ class DeploySerializerTest(TestCase):
         user = self.create_user()
         repo = self.create_repo()
         app = self.create_app(repository=repo)
+        self.create_taskconfig(app=app)
         task = self.create_task(app=app, user=user, status=TaskStatus.pending)
         deploy = self.create_deploy(app=app, task=task)
 

--- a/tests/api/test_app_index.py
+++ b/tests/api/test_app_index.py
@@ -23,6 +23,7 @@ class AppListTest(AppIndexBase):
         app = self.create_app(
             repository=self.repo,
         )
+        self.create_taskconfig(app=app)
         resp = self.client.get(self.path)
         assert resp.status_code == 200
         data = json.loads(resp.data)
@@ -34,6 +35,7 @@ class AppListTest(AppIndexBase):
             repository=self.repo,
             name='foobar',
         )
+        self.create_taskconfig(app=app)
         resp = self.client.get(self.path + '?name=' + app.name)
         assert resp.status_code == 200
         data = json.loads(resp.data)
@@ -62,16 +64,17 @@ class AppCreateTest(AppIndexBase):
         assert data['id']
 
         app = App.query.get(data['id'])
+        deploy_config = app.deploy_config
         assert app.name == 'foobar'
-        assert app.provider == 'shell'
-        assert app.provider_config['command'] == '/usr/bin/true'
-        assert app.provider_config['timeout'] == 50
-        assert app.notifiers == [
+        assert deploy_config.provider == 'shell'
+        assert deploy_config.provider_config['command'] == '/usr/bin/true'
+        assert deploy_config.provider_config['timeout'] == 50
+        assert deploy_config.notifiers == [
             {'type': 'slack', 'config': {'webhook_url': 'https://example.com'}},
         ]
-        assert len(app.checks) == 1
-        assert app.checks[0]['type'] == 'github'
-        assert app.checks[0]['config'] == {'contexts': ['travisci'], 'repo': 'getsentry/freight'}
+        assert len(deploy_config.checks) == 1
+        assert deploy_config.checks[0]['type'] == 'github'
+        assert deploy_config.checks[0]['config'] == {'contexts': ['travisci'], 'repo': 'getsentry/freight'}
         assert len(app.environments) == 1
         assert app.environments['staging'] == {'default_ref': 'develop'}
 

--- a/tests/api/test_deploy_details.py
+++ b/tests/api/test_deploy_details.py
@@ -12,6 +12,7 @@ class DeployDetailsBase(TestCase):
         self.user = self.create_user()
         self.repo = self.create_repo()
         self.app = self.create_app(repository=self.repo)
+        self.deploy_config = self.create_taskconfig(app=self.app)
         self.task = self.create_task(app=self.app, user=self.user)
         self.deploy = self.create_deploy(app=self.app, task=self.task)
         self.path = '/api/0/deploys/{}/'.format(self.deploy.id)

--- a/tests/api/test_deploy_index.py
+++ b/tests/api/test_deploy_index.py
@@ -15,6 +15,7 @@ class DeployIndexBase(TestCase):
         self.user = self.create_user()
         self.repo = self.create_repo()
         self.app = self.create_app(repository=self.repo)
+        self.deploy_config = self.create_taskconfig(app=self.app)
         super(DeployIndexBase, self).setUp()
 
 
@@ -158,8 +159,8 @@ class DeployCreateTest(DeployIndexBase):
         assert task.app_id == self.app.id
         assert task.ref == 'master'
         assert task.user_id == self.user.id
-        assert task.provider_config == self.app.provider_config
-        assert task.notifiers == self.app.notifiers
+        assert task.provider_config == self.deploy_config.provider_config
+        assert task.notifiers == self.deploy_config.notifiers
 
     def test_custom_params(self):
         resp = self.client.post(self.path, data={
@@ -182,8 +183,8 @@ class DeployCreateTest(DeployIndexBase):
         assert task.app_id == self.app.id
         assert task.ref == 'master'
         assert task.user_id == self.user.id
-        assert task.provider_config == self.app.provider_config
-        assert task.notifiers == self.app.notifiers
+        assert task.provider_config == self.deploy_config.provider_config
+        assert task.notifiers == self.deploy_config.notifiers
 
         assert task.params == {'task': 'collectstatic'}
 

--- a/tests/api/test_deploy_log.py
+++ b/tests/api/test_deploy_log.py
@@ -12,6 +12,7 @@ class DeployLogBase(TestCase):
         self.user = self.create_user()
         self.repo = self.create_repo()
         self.app = self.create_app(repository=self.repo)
+        self.deploy_config = self.create_taskconfig(app=self.app)
         self.task = self.create_task(app=self.app, user=self.user)
         self.deploy = self.create_deploy(app=self.app, task=self.task)
         self.path = '/api/0/deploys/{}/log/'.format(self.deploy.id)

--- a/tests/notifiers/test_queue.py
+++ b/tests/notifiers/test_queue.py
@@ -10,6 +10,7 @@ class NotificationQueueTest(TestCase):
         self.user = self.create_user()
         self.repo = self.create_repo()
         self.app = self.create_app(repository=self.repo)
+        self.deploy_config = self.create_taskconfig(app=self.app)
         self.task = self.create_task(
             app=self.app,
             user=self.user,

--- a/tests/notifiers/test_sentry.py
+++ b/tests/notifiers/test_sentry.py
@@ -15,6 +15,7 @@ class SentryNotifierBase(TestCase):
         self.user = self.create_user()
         self.repo = self.create_repo()
         self.app = self.create_app(repository=self.repo)
+        self.deploy_config = self.create_taskconfig(app=self.app)
         self.task = self.create_task(
             app=self.app,
             user=self.user,

--- a/tests/notifiers/test_slack.py
+++ b/tests/notifiers/test_slack.py
@@ -17,6 +17,7 @@ class SlackNotifierBase(TestCase):
         self.user = self.create_user()
         self.repo = self.create_repo()
         self.app = self.create_app(repository=self.repo)
+        self.deploy_config = self.create_taskconfig(app=self.app)
         self.task = self.create_task(
             app=self.app,
             user=self.user,

--- a/tests/notifiers/test_utils.py
+++ b/tests/notifiers/test_utils.py
@@ -15,6 +15,7 @@ class SendTaskNotificationsTest(TestCase):
         self.user = self.create_user()
         self.repo = self.create_repo()
         self.app = self.create_app(repository=self.repo)
+        self.deploy_config = self.create_taskconfig(app=self.app)
         self.task = self.create_task(
             app=self.app,
             user=self.user,
@@ -48,6 +49,7 @@ class ClearTaskNotificationsTest(TestCase):
         self.user = self.create_user()
         self.repo = self.create_repo()
         self.app = self.create_app(repository=self.repo)
+        self.deploy_config = self.create_taskconfig(app=self.app)
         self.task = self.create_task(
             app=self.app,
             user=self.user,

--- a/tests/providers/test_shell.py
+++ b/tests/providers/test_shell.py
@@ -14,6 +14,7 @@ class ShellProviderBase(TestCase):
         self.user = self.create_user()
         self.repo = self.create_repo()
         self.app = self.create_app(repository=self.repo)
+        self.deploy_config = self.create_taskconfig(app=self.app)
         self.task = self.create_task(app=self.app, user=self.user)
         self.deploy = self.create_deploy(app=self.app, task=self.task)
 

--- a/tests/tasks/test_check_queue.py
+++ b/tests/tasks/test_check_queue.py
@@ -13,6 +13,7 @@ class CheckQueueTestCase(TransactionTestCase):
         user = self.create_user()
         repo = self.create_repo()
         app = self.create_app(repository=repo)
+        deploy_config = self.create_taskconfig(app=app)
         task = self.create_task(
             app=app, user=user, status=TaskStatus.pending,
         )
@@ -30,6 +31,7 @@ class CheckQueueTestCase(TransactionTestCase):
         user = self.create_user()
         repo = self.create_repo()
         app = self.create_app(repository=repo)
+        deploy_config = self.create_taskconfig(app=app)
         task = self.create_task(
             app=app, user=user, status=TaskStatus.in_progress,
         )

--- a/tests/tasks/test_delete_object.py
+++ b/tests/tasks/test_delete_object.py
@@ -10,6 +10,7 @@ class DeleteObjectTest(TestCase):
         user = self.create_user()
         repo = self.create_repo()
         app = self.create_app(repository=repo)
+        deploy_config = self.create_taskconfig(app=app)
         task = self.create_task(app=app, user=user)
 
         queue.apply('freight.jobs.delete_object', kwargs={

--- a/tests/tasks/test_execute_task.py
+++ b/tests/tasks/test_execute_task.py
@@ -13,6 +13,7 @@ class ExecuteTaskTestCase(TransactionTestCase):
         user = self.create_user()
         repo = self.create_repo()
         app = self.create_app(repository=repo)
+        self.create_taskconfig(app=app)
         task = self.create_task(app=app, user=user)
         deploy = self.create_deploy(app=app, task=task)
         db.session.commit()

--- a/tests/tasks/test_send_pending_notifications.py
+++ b/tests/tasks/test_send_pending_notifications.py
@@ -24,6 +24,7 @@ class SendPendingNotificationsTestCase(TransactionTestCase):
         user = self.create_user()
         repo = self.create_repo()
         app = self.create_app(repository=repo)
+        self.create_taskconfig(app=app)
         task = self.create_task(
             app=app, user=user, status=TaskStatus.pending,
         )


### PR DESCRIPTION
This makes TaskConfig a many-to-one with App, allowing multiple
different providers to be configured for an App. This allows different
configurations for deploy/build type tasks.

Right now, this is fully backwards compatible and assumes that the only
type of TaskConfig that will exist is "deploy". This allows the API to
be expanded next to add build configs.

/cc @dcramer 