### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -69,7 +69,7 @@ deploy a version" which could assist in pull-based deploys.
 Resources
 =========
 
-- `Documentation <http://freight.readthedocs.org>`_
+- `Documentation <https://freight.readthedocs.io>`_
 - `Bug Tracker <https://github.com/getsentry/freight/issues>`_
 - `Code <https://github.com/getsentry/freight>`_
 - `IRC <irc://irc.freenode.net/sentry>`_  (irc.freenode.net, #sentry)


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.