### PR TITLE
Support for autodeploy via webhook

### DIFF
--- a/freight/api/base.py
+++ b/freight/api/base.py
@@ -5,6 +5,7 @@ import json
 from flask import current_app, request, Response
 from flask_restful import Resource
 from urllib import quote
+from hmac import compare_digest
 
 from freight.config import db
 from freight.exceptions import ApiError
@@ -32,7 +33,7 @@ class ApiView(Resource):
         if method != 'Key':
             return False
 
-        if payload != current_app.config['API_KEY']:
+        if not compare_digest(payload.decode('utf8'), current_app.config['API_KEY'].decode('utf8')):
             return False
 
         return True

--- a/freight/config.py
+++ b/freight/config.py
@@ -222,13 +222,16 @@ def configure_web_routes(app):
     from freight.web.auth import AuthorizedView, LoginView, LogoutView
     from freight.web.index import IndexView
     from freight.web.static import StaticView
+    from freight.web.webhooks import WebhooksView
 
     static_root = os.path.join(PROJECT_ROOT, 'dist')
 
     app.add_url_rule(
         '/static/<path:filename>',
         view_func=StaticView.as_view(b'static', root=static_root))
-
+    app.add_url_rule(
+        '/webhooks/<hook>/<action>/<app>/<env>/<digest>/',
+        view_func=WebhooksView.as_view(b'webhooks'))
     app.add_url_rule(
         '/auth/login/',
         view_func=LoginView.as_view(b'login', authorized_url='authorized'))

--- a/freight/exceptions.py
+++ b/freight/exceptions.py
@@ -48,3 +48,7 @@ class InvalidNotifier(KeyError):
 
 class InvalidCheck(KeyError):
     pass
+
+
+class InvalidHook(KeyError):
+    pass

--- a/freight/hooks/__init__.py
+++ b/freight/hooks/__init__.py
@@ -1,0 +1,9 @@
+from __future__ import absolute_import
+
+from .manager import HooksManager
+from .github import GitHubHooks
+
+manager = HooksManager()
+manager.add('github', GitHubHooks)
+
+get = manager.get

--- a/freight/hooks/base.py
+++ b/freight/hooks/base.py
@@ -1,0 +1,8 @@
+from __future__ import absolute_import
+
+__all__ = ['Hook']
+
+
+class Hook(object):
+    def deploy(self, app, env):
+        raise NotImplementedError

--- a/freight/hooks/github.py
+++ b/freight/hooks/github.py
@@ -1,0 +1,41 @@
+from __future__ import absolute_import
+
+__all__ = ['GitHubHooks']
+
+from flask import current_app, request, Response
+
+from .base import Hook
+from freight.testutils.client import AuthenticatedTestClient
+
+
+class GitHubHooks(Hook):
+    def ok(self):
+        return Response()
+
+    def deploy(self, app, env):
+        payload = request.get_json()
+        event = request.headers.get('X-GitHub-Event')
+
+        if event != 'push':
+            # Gracefully ignore everything except push events
+            return self.ok()
+
+        default_ref = app.get_default_ref(env)
+        ref = payload['ref']
+
+        if ref != 'refs/heads/{}'.format(default_ref):
+            return self.ok()
+
+        head_commit = payload['head_commit']
+        committer = head_commit['committer']
+
+        client = AuthenticatedTestClient(
+            current_app, current_app.response_class
+        )
+
+        return client.post('/api/0/deploys/', data={
+            'env': env,
+            'app': app.name,
+            'ref': head_commit['id'],
+            'user': head_commit['committer']['email'],
+        })

--- a/freight/hooks/manager.py
+++ b/freight/hooks/manager.py
@@ -1,0 +1,20 @@
+from __future__ import absolute_import
+
+__all__ = ['HooksManager']
+
+from freight.exceptions import InvalidHook
+
+
+class HooksManager(object):
+    def __init__(self):
+        self._register = {}
+
+    def add(self, name, cls):
+        self._register[name] = cls
+
+    def get(self, name, **kwargs):
+        try:
+            cls = self._register[name]
+        except KeyError:
+            raise InvalidHook(name)
+        return cls(**kwargs)

--- a/freight/web/webhooks.py
+++ b/freight/web/webhooks.py
@@ -1,0 +1,47 @@
+from __future__ import absolute_import
+
+import hmac
+from hashlib import sha256
+
+from flask import current_app, Response
+from flask.views import MethodView
+
+from freight import hooks
+from freight.models import App
+from freight.exceptions import InvalidHook
+
+
+class WebhooksView(MethodView):
+    def respond(self, body='', status_code=200):
+        rv = Response(body)
+        rv.status_code = status_code
+        return rv
+
+    def get(self, *args, **kwargs):
+        rv = Response()
+        rv.status_code = 405
+        return rv
+
+    def post(self, hook, action, app, env, digest):
+        expected = hmac.new(current_app.config['API_KEY'], '%s/%s/%s/%s' % (
+            hook, action, app, env,
+        ), sha256).hexdigest()
+        if not hmac.compare_digest(expected, digest.encode('utf8')):
+            return self.respond(status_code=403)
+
+        try:
+            hook = hooks.get(hook)
+        except InvalidHook:
+            return self.respond('Invalid hook', status_code=404)
+
+        if action != 'deploy':
+            return self.respond('Unknown action', status_code=404)
+
+        app = App.query.filter(App.name == app).first()
+        if app is None:
+            return self.respond('Invalid app', status_code=404)
+
+        try:
+            return hook.deploy(app, env)
+        except NotImplementedError:
+            return self.respond(status_code=404)

--- a/tests/web/test_webhooks.py
+++ b/tests/web/test_webhooks.py
@@ -1,0 +1,35 @@
+from __future__ import absolute_import
+
+import hmac
+from hashlib import sha256
+
+from flask import current_app
+
+from freight.testutils import TestCase
+
+
+class WebhooksViewTest(TestCase):
+    def make_path(self, hook, action, app, env='production', digest=None):
+        key = '{}/{}/{}/{}'.format(hook, action, app, env)
+        if digest is None:
+            api_key = current_app.config['API_KEY']
+            digest = hmac.new(api_key, key, sha256).hexdigest()
+        return '/webhooks/{}/{}/'.format(key, digest)
+
+    def test_bad_digest(self):
+        resp = self.client.post(
+            self.make_path('github', 'deploy', 'test', digest='xxxx'),
+        )
+        assert resp.status_code == 403, resp.data
+
+    def test_invalid_hook(self):
+        resp = self.client.post(
+            self.make_path('xxx', 'deploy', 'test'),
+        )
+        assert resp.status_code == 404, resp.data
+
+    def test_invalid_app(self):
+        resp = self.client.post(
+            self.make_path('github', 'deploy', 'test'),
+        )
+        assert resp.status_code == 404, resp.data


### PR DESCRIPTION
See https://github.com/getsentry/freight-cli/commit/1f7379e1f4f3d5cf88815b965bea595a69ca6a3d for context on how the webhook url is generated.

It's just a signed url pointing to an app and environment signed with the `API_KEY`, so it's possible to use to generate and sign new webhook urls.