### PR TITLE
Vagrant development environment

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,15 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+
+  # this is a third-party xenial image because:
+  #  1. trusty has a python 2.7 that's too old and upgrading more or less requires fetch & compile
+  #  2. canonical's xenial image is broken under vagrant: https://bugs.launchpad.net/cloud-images/+bug/1569237
+  config.vm.box = "bento/ubuntu-16.04"
+
+  # default flask debug server port
+  config.vm.network "forwarded_port", guest: 5000, host: 5000
+
+  config.vm.provision "shell", path: "bin/setup-dev-env", privileged: false
+end

--- a/bin/setup-dev-env
+++ b/bin/setup-dev-env
@@ -2,17 +2,24 @@
 # sets up a linux system (e.g. a virtualbox VM managed by Vagrant) to be a dev environment
 
 ag () {
-    sudo DEBIAN_FRONTEND=noninteractive apt-get ${@} -yq --no-install-recommends
+    sudo DEBIAN_FRONTEND=noninteractive apt-get -yqq --no-install-recommends ${@}
 }
 
 sql () {
     sudo -u postgres psql -d postgres -c "${@}"
 }
 
+# add node repo
+curl --silent https://deb.nodesource.com/gpgkey/nodesource.gpg.key | sudo apt-key add -
+echo "deb https://deb.nodesource.com/node_7.x xenial main" | sudo tee /etc/apt/sources.list.d/nodesource.list
+
+# update system
 ag update
 ag dist-upgrade
 ag autoremove
-ag install python-dev libffi-dev libssl-dev redis-server postgresql python-pip virtualenvwrapper libpq-dev git libkrb5-dev
+
+# install packages
+ag install python-dev libffi-dev libssl-dev redis-server postgresql python-pip virtualenvwrapper libpq-dev git libkrb5-dev nodejs
 
 
 # setup db
@@ -34,24 +41,21 @@ sudo service postgresql restart
 
 
 # set up node
-curl --silent https://deb.nodesource.com/gpgkey/nodesource.gpg.key | sudo apt-key add -
-echo "deb https://deb.nodesource.com/node_7.x xenial main" | sudo tee /etc/apt/sources.list.d/nodesource.list
-ag update
-ag install nodejs
-
 pushd /vagrant
 npm install
 popd
 
 
 # set up python
-sudo -H pip install --upgrade pip setuptools urllib3[secure] virtualenvwrapper
+sudo -H pip install -qq --upgrade pip setuptools urllib3[secure] virtualenvwrapper
 
 . /etc/bash_completion.d/virtualenvwrapper
 
 mkvirtualenv --system-site-packages freight
-pip install -r /vagrant/requirements.txt
-pip install -r /vagrant/requirements-test.txt
+pip install -qqr /vagrant/requirements.txt
+pip install -qqr /vagrant/requirements-test.txt
 add2virtualenv /vagrant
+pushd /vagrant
 alembic upgrade head
+popd
 deactivate

--- a/bin/setup-dev-env
+++ b/bin/setup-dev-env
@@ -5,21 +5,33 @@ ag () {
     sudo DEBIAN_FRONTEND=noninteractive apt-get ${@} -yq --no-install-recommends
 }
 
+sql () {
+    sudo -u postgres psql -d postgres -c "${@}"
+}
+
 ag update
 ag dist-upgrade
 ag autoremove
 ag install python-dev libffi-dev libssl-dev redis-server postgresql python-pip virtualenvwrapper libpq-dev git libkrb5-dev
 
-# set up python
-sudo -H pip install --upgrade pip setuptools urllib3[secure] virtualenvwrapper
 
-. /etc/bash_completion.d/virtualenvwrapper
+# setup db
+sql 'alter role postgres with inherit;'
+sql 'create role vagrant with login createdb;'
+sql 'grant postgres to vagrant;'
+sql 'create database freight;'
+sql 'create database test_freight;'
 
-mkvirtualenv --system-site-packages freight
-pip install -r /vagrant/requirements.txt
-pip install -r /vagrant/requirements-test.txt
-add2virtualenv /vagrant
-deactivate
+# remove all restrictions on db access
+cat <<EOF | sudo tee /etc/postgresql/9.5/main/pg_hba.conf
+local   all             all                                     trust
+local   all             all                                     trust
+host    all             all             127.0.0.1/32            trust
+host    all             all             ::1/128                 trust
+EOF
+
+sudo service postgresql restart
+
 
 # set up node
 curl --silent https://deb.nodesource.com/gpgkey/nodesource.gpg.key | sudo apt-key add -
@@ -31,4 +43,15 @@ pushd /vagrant
 npm install
 popd
 
-# setup db
+
+# set up python
+sudo -H pip install --upgrade pip setuptools urllib3[secure] virtualenvwrapper
+
+. /etc/bash_completion.d/virtualenvwrapper
+
+mkvirtualenv --system-site-packages freight
+pip install -r /vagrant/requirements.txt
+pip install -r /vagrant/requirements-test.txt
+add2virtualenv /vagrant
+alembic upgrade head
+deactivate

--- a/bin/setup-dev-env
+++ b/bin/setup-dev-env
@@ -42,7 +42,7 @@ sudo service postgresql restart
 
 # set up node
 pushd /vagrant
-npm install
+npm install --silent
 popd
 
 

--- a/bin/setup-dev-env
+++ b/bin/setup-dev-env
@@ -24,7 +24,7 @@ deactivate
 # set up node
 curl --silent https://deb.nodesource.com/gpgkey/nodesource.gpg.key | sudo apt-key add -
 echo "deb https://deb.nodesource.com/node_7.x xenial main" | sudo tee /etc/apt/sources.list.d/nodesource.list
-sudo DEBIAN_FRONTEND=noninteractive apt-get install -yq nodejs
+ag install nodejs
 
 pushd /vagrant
 npm install

--- a/bin/setup-dev-env
+++ b/bin/setup-dev-env
@@ -41,6 +41,7 @@ sudo service postgresql restart
 
 
 # set up node
+sudo -H npm install -g webpack
 pushd /vagrant
 npm install --silent
 popd

--- a/bin/setup-dev-env
+++ b/bin/setup-dev-env
@@ -19,7 +19,7 @@ ag dist-upgrade
 ag autoremove
 
 # install packages
-ag install python-dev libffi-dev libssl-dev redis-server postgresql python-pip virtualenvwrapper libpq-dev git libkrb5-dev nodejs
+ag install python-dev libffi-dev libssl-dev redis-server postgresql python-pip virtualenvwrapper libpq-dev git libkrb5-dev nodejs g++ build-essential
 
 
 # setup db

--- a/bin/setup-dev-env
+++ b/bin/setup-dev-env
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # sets up a linux system (e.g. a virtualbox VM managed by Vagrant) to be a dev environment
 
-ag () {
+aptgetquiet () {
     sudo DEBIAN_FRONTEND=noninteractive apt-get -yqq --no-install-recommends ${@}
 }
 
@@ -11,15 +11,15 @@ sql () {
 
 # add node repo
 curl --silent https://deb.nodesource.com/gpgkey/nodesource.gpg.key | sudo apt-key add -
-echo "deb https://deb.nodesource.com/node_7.x xenial main" | sudo tee /etc/apt/sources.list.d/nodesource.list
+echo "deb https://deb.nodesource.com/node_4.x xenial main" | sudo tee /etc/apt/sources.list.d/nodesource.list
 
 # update system
-ag update
-ag dist-upgrade
-ag autoremove
+aptgetquiet update
+aptgetquiet dist-upgrade
+aptgetquiet autoremove
 
 # install packages
-ag install python-dev libffi-dev libssl-dev redis-server postgresql python-pip virtualenvwrapper libpq-dev git libkrb5-dev nodejs g++ build-essential
+aptgetquiet install python-dev libffi-dev libssl-dev redis-server postgresql python-pip virtualenvwrapper libpq-dev git libkrb5-dev nodejs g++ build-essential
 
 
 # setup db

--- a/bin/setup-dev-env
+++ b/bin/setup-dev-env
@@ -24,6 +24,7 @@ deactivate
 # set up node
 curl --silent https://deb.nodesource.com/gpgkey/nodesource.gpg.key | sudo apt-key add -
 echo "deb https://deb.nodesource.com/node_7.x xenial main" | sudo tee /etc/apt/sources.list.d/nodesource.list
+ag update
 ag install nodejs
 
 pushd /vagrant

--- a/bin/setup-dev-env
+++ b/bin/setup-dev-env
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# sets up a linux system (e.g. a virtualbox VM managed by Vagrant) to be a dev environment
+
+ag () {
+    sudo DEBIAN_FRONTEND=noninteractive apt-get ${@} -yq --no-install-recommends
+}
+
+ag update
+ag dist-upgrade
+ag autoremove
+ag install python-dev libffi-dev libssl-dev redis-server postgresql python-pip virtualenvwrapper libpq-dev git libkrb5-dev
+
+# set up python
+sudo -H pip install --upgrade pip setuptools urllib3[secure] virtualenvwrapper
+
+. /etc/bash_completion.d/virtualenvwrapper
+
+mkvirtualenv --system-site-packages freight
+pip install -r /vagrant/requirements.txt
+pip install -r /vagrant/requirements-test.txt
+add2virtualenv /vagrant
+deactivate
+
+# set up node
+curl --silent https://deb.nodesource.com/gpgkey/nodesource.gpg.key | sudo apt-key add -
+echo "deb https://deb.nodesource.com/node_7.x xenial main" | sudo tee /etc/apt/sources.list.d/nodesource.list
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -yq nodejs
+
+pushd /vagrant
+npm install
+popd
+
+# setup db


### PR DESCRIPTION

```
(freight) vagrant@vagrant:/vagrant$ bin/test
+ py.test tests
=============================================================================================== test session starts ================================================================================================
platform linux2 -- Python 2.7.12 -- py-1.4.33 -- pytest-2.5.2
plugins: timeout, cov, xdist
collected 82 items 

tests/api/test_app_details.py ...........
tests/api/test_app_index.py ..........
tests/api/test_controller.py .
tests/api/test_deploy_details.py ....
tests/api/test_deploy_index.py .............
tests/api/test_deploy_log.py ....
tests/api/serializer/test_app.py .
tests/api/serializer/test_deploy.py .
tests/api/serializer/test_user.py .
tests/checks/test_github.py ......
tests/notifiers/test_githubnotifier.py ..
tests/notifiers/test_queue.py .
tests/notifiers/test_sentry.py ..
tests/notifiers/test_slack.py ..
tests/notifiers/test_utils.py ...
tests/providers/test_shell.py ......
tests/tasks/test_check_queue.py ...
tests/tasks/test_delete_object.py .
tests/tasks/test_execute_task.py .
tests/tasks/test_send_pending_notifications.py .
tests/vcs/test_git.py .....
tests/web/test_webhooks.py ...

============================================================================================ 82 passed in 8.43 seconds =============================================================================================
(freight) vagrant@vagrant:/vagrant$ 

```