### PR TITLE
Fixed redeploy button.

### DIFF
--- a/static/components/TaskDetails.jsx
+++ b/static/components/TaskDetails.jsx
@@ -250,8 +250,10 @@ var TaskDetails = React.createClass({
           ref: task.sha,
         },
         success: (data) => {
-          let {app, environment, number} = this.props.task;
-          browserHistory.push(`/deploys/${app.name}/${environment}/${number}`);
+         browserHistory.push(`/deploys/${data.app.name}/${data.environment}/${data.number}`);
+         //full window reload.
+         // TODO: rerender page with existing functions.
+         window.location.reload()
         }
       });
     });

--- a/static/components/TaskDetails.jsx
+++ b/static/components/TaskDetails.jsx
@@ -241,7 +241,6 @@ var TaskDetails = React.createClass({
       submitInProgress: true,
     }, () => {
       let task = this.state.task;
-
       api.request('/deploys/', {
         method: 'POST',
         data: {
@@ -250,12 +249,10 @@ var TaskDetails = React.createClass({
           ref: task.sha,
         },
         success: (data) => {
-         browserHistory.push(`/deploys/${data.app.name}/${data.environment}/${data.number}`);
-         //full window reload.
-         // TODO: rerender page with existing functions.
-         window.location.reload()
-        }
-      });
+          browserHistory.push('/');
+          browserHistory.push(`/deploys/${data.app.name}/${data.environment}/${data.number}`);
+       },
+     });
     });
   },
 

--- a/static/components/TaskDetails.jsx
+++ b/static/components/TaskDetails.jsx
@@ -113,19 +113,16 @@ var TaskDetails = React.createClass({
       task: data
     });
   },
-
   updateBuildLog(data) {
     // add each additional new line
-    var frag       = document.getElementsByClassName('frag')[0] || document.createDocumentFragment();
-    frag.className = 'frag';
-
+    var frag       = document.createDocumentFragment();
     var text       = data.chunks
     var objLength  = data.chunks.length
-
 
     for(var i = 0; i < objLength; i++){
       var timer    = new Date(data.chunks[i].date)
       var timeMil  = timer.getTime()
+
       //Multiple by 60000 to convert offset to milliseconds
       var offset   = timer.getTimezoneOffset() * 60000
       var timezone = timeMil - offset


### PR DESCRIPTION
Clicking redeploy now directs to the correct url.
*EDIT*
Renders without reload now.
![imjx5zpbkc](https://user-images.githubusercontent.com/1907496/28091486-c8f45d88-6644-11e7-94c1-d66c94e7eac9.gif)

```javascript
  browserHistory.push('/');
  browserHistory.push(`/deploys/${data.app.name}/${data.environment}/${data.number}`);
```
This solution is loosely based off workarounds found here: https://github.com/ReactTraining/react-router/issues/1982
