### PR TITLE
Fix issue where contexts aren't being ignored correctly

### DIFF
--- a/freight/checks/github.py
+++ b/freight/checks/github.py
@@ -32,7 +32,8 @@ class GitHubContextCheck(Check):
             config.get('api_root') or current_app.config['GITHUB_API_ROOT']
         ).rstrip('/')
 
-        contexts = set(config.get('contexts') or [])
+        all_contexts = set(config.get('contexts') or [])
+        contexts = all_contexts.copy()
         repo = config['repo']
 
         url = '{api_root}/repos/{repo}/commits/{ref}/statuses'.format(
@@ -54,6 +55,8 @@ class GitHubContextCheck(Check):
 
         valid_contexts = set()
         for data in context_list:
+            if all_contexts and data['context'] not in all_contexts:
+                continue
             if data['state'] == 'success':
                 valid_contexts.add(data['context'])
                 try:

--- a/tests/checks/test_github.py
+++ b/tests/checks/test_github.py
@@ -123,3 +123,27 @@ class GitHubContextCheckTest(GitHubCheckBase):
 
         with pytest.raises(CheckFailed):
             self.check.check(self.app, 'abcdefg', config)
+
+    @responses.activate
+    def test_partial_failed_context(self):
+        body = json.dumps([
+            {
+                "state": "success",
+                "context": "travisci",
+                "description": "we did it",
+                "target_url": "example.com/build",
+            },
+            {
+                "state": "failing",
+                "context": "somethingelse",
+                "description": "we didn't do it",
+                "target_url": "example.com/build",
+            },
+        ])
+
+        responses.add(responses.GET, 'https://api.github.com/repos/getsentry/freight/commits/abcdefg/statuses',
+                      body=body)
+
+        config = {'contexts': ['travisci'], 'repo': 'getsentry/freight'}
+
+        self.check.check(self.app, 'abcdefg', config)


### PR DESCRIPTION
When there's a partial success/failure, the contexts set was being
mutated down to being empty. And empty meant the same thing as "all
checks must pass". So this yields a copy of the contexts which are used
strictly for checking against.