### PR TITLE
fail Notification in safari gracefully

### DIFF
--- a/static/components/Overview.jsx
+++ b/static/components/Overview.jsx
@@ -76,7 +76,7 @@ var Overview = React.createClass({
       );
     }
 
-    if(Notification.permission !== 'denied'){
+    if(window.Notification && Notification.permission !== 'denied'){
       Notification.requestPermission()
     }
 

--- a/static/components/TaskDetails.jsx
+++ b/static/components/TaskDetails.jsx
@@ -389,7 +389,7 @@ var TaskDetails = React.createClass({
       );
     }
 
-    if(Notification.permission !== 'denied'){
+    if(window.Notification && Notification.permission !== 'denied'){
       Notification.requestPermission()
     }
 

--- a/static/less/base.less
+++ b/static/less/base.less
@@ -406,7 +406,7 @@ header {
       margin-right: 70px;
     }
     .highLighted{
-      background-color: #3a905b;
+      background-color: #1D0D38;
     }
     .time{
       width: 57px;

--- a/static/pushNotification.js
+++ b/static/pushNotification.js
@@ -23,7 +23,7 @@ function pushNotification(task, path){
     }
   }
 
-  if(Notification.permission !== 'denied'){
+  if(window.Notification && Notification.permission !== 'denied'){
     Notification.requestPermission(function(permission){
       if(permission === 'granted'){
         createNotification(task.name, url, options);


### PR DESCRIPTION
`Notification` on it's own is a reference error in safari, not undefined. this pulls it off window so it's undefined