### PR TITLE
move GCP CLI setup for GCR purposes to separate script

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -17,8 +17,8 @@ if [ "$DOCKER_CONFIG" ]; then
     unset DOCKER_CONFIG
 fi
 
-if [ -f /etc/freight/gcr-auth.sh ]; then
-    . /etc/freight/gcr-auth.sh
+if [ -f /etc/freight/auth-helpers.sh ]; then
+    . /etc/freight/auth-helpers.sh
 fi
 
 # Check if we're trying to execute a freight bin

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -17,17 +17,8 @@ if [ "$DOCKER_CONFIG" ]; then
     unset DOCKER_CONFIG
 fi
 
-if [ "$GCP_PROJECT" ]; then
-    gosu freight bash -c 'gcloud auth configure-docker'
-    gosu freight bash -c 'mkdir -p ~freight/.config/gcloud/configurations/'
-    cat<<-HERE | gosu freight bash -c 'tee > ~freight/.config/gcloud/configurations/config_default'
-	[core]
-	project = $GCP_PROJECT
-
-	[compute]
-	zone = $GCP_ZONE
-	region = $GCP_REGION
-HERE
+if [ -f /etc/freight/gcr-auth.sh ]; then
+    . /etc/freight/gcr-auth.sh
 fi
 
 # Check if we're trying to execute a freight bin


### PR DESCRIPTION
#132 added the Google Cloud Platform SDK to this container so that Google Cloud Registry could be used for Docker images.

Unfortunately, most of the ways to authenticate and authorize access to GCP are environment-specific and vary wildly. Instead of relying on environment vars set by `docker run`, this PR checks for a script mounted into the container and runs that instead, allowing everyone to customize their login steps as needed.