### PR TITLE
Fix Travis tests: 2018 edition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ cache:
 env:
   global:
     - PIP_DOWNLOAD_CACHE=".pip_download_cache"
-    - TRAVIS_NODE_VERSION=4
+    - TRAVIS_NODE_VERSION=4.7.0
 install:
   - nvm install $TRAVIS_NODE_VERSION
   - time make develop

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ flask-redis>=0.0.6,<0.1.0
 flask-restful>=0.3.4,<0.4.0
 Flask-Webpack==0.1.0
 oauth2client>=1.2,<1.3
-psycopg2>=2.5.1,<2.6.0
+psycopg2>=2.7,<2.8
 raven>=5.1.1,<5.2.0
 redis>=2.10.3,<2.11.0
 requests>=2.5.1,<2.6.0


### PR DESCRIPTION
1. Pin node.js to specific version that we know works.
2. Upgrade Psycopg2 because Travis upgraded postgresql and libpq.
