### PR TITLE
[DO NOT MERGE] feat: Craft provider for publishing releases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ npm-debug.log
 .env
 venv/
 freight_venv
+stats.json

--- a/freight/api/app_index.py
+++ b/freight/api/app_index.py
@@ -79,7 +79,8 @@ class AppIndexApiView(ApiView):
         # on the app at all times.
         deploy_config = TaskConfig(
             app_id=app.id,
-            type=TaskConfigType.deploy,
+            # FIXME This should be included in API
+            type=TaskConfigType.release if 'release' in args.name else TaskConfigType.deploy,
             provider=args.provider,
             data={
                 'provider_config': provider_config,

--- a/freight/api/deploy_index.py
+++ b/freight/api/deploy_index.py
@@ -11,7 +11,7 @@ from freight.config import db, redis
 from freight.exceptions import CheckError, CheckPending
 from freight.models import (
     App, Repository, Task, Deploy, DeploySequence, TaskStatus, User,
-    TaskConfig, TaskConfigType,
+    TaskConfig,
 )
 from freight.notifiers import NotifierEvent
 from freight.notifiers.utils import send_task_notifications
@@ -116,9 +116,9 @@ class DeployIndexApiView(ApiView):
             return self.error('Invalid app', name='invalid_resource', status_code=404)
 
         deploy_config = TaskConfig.query.filter(
-            TaskConfig.app_id == app.id,
-            TaskConfig.type == TaskConfigType.deploy,
+            TaskConfig.app_id == app.id
         ).first()
+
         if not deploy_config:
             return self.error('Missing deploy config', name='missing_conf', status_code=404)
 

--- a/freight/api/serializer/app.py
+++ b/freight/api/serializer/app.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from freight.models import App, Repository
+from freight.models import App, Repository, TaskConfig
 
 from .base import Serializer
 from .manager import add
@@ -25,9 +25,15 @@ class AppSerializer(Serializer):
         else:
             repo = None
 
+        # Let's assume that we have only one TaskConfig per App for now
+        task_config = TaskConfig.query.filter(
+            TaskConfig.app_id == item.id,
+        ).first()
+
         return {
             'id': str(item.id),
             'name': item.name,
             'environments': env_map,
+            'type': task_config.type,
             'repository': repo,
         }

--- a/freight/models/taskconfig.py
+++ b/freight/models/taskconfig.py
@@ -9,6 +9,7 @@ from freight.db.types.json import JSONEncodedDict
 
 class TaskConfigType(object):
     deploy = 0
+    release = 1
 
     @classmethod
     def get_label(cls, status):
@@ -21,6 +22,7 @@ class TaskConfigType(object):
 
 TYPE_LABELS = {
     TaskConfigType.deploy: 'deploy',
+    TaskConfigType.release: 'release',
 }
 TYPE_LABELS_REV = {
     v: k for k, v in TYPE_LABELS.items()

--- a/freight/providers/__init__.py
+++ b/freight/providers/__init__.py
@@ -2,8 +2,10 @@ from __future__ import absolute_import
 
 from .manager import ProviderManager
 from .shell import ShellProvider
+from .craft import CraftProvider
 
 manager = ProviderManager()
 manager.add('shell', ShellProvider)
+manager.add('craft', CraftProvider)
 
 get = manager.get

--- a/freight/providers/craft.py
+++ b/freight/providers/craft.py
@@ -1,0 +1,33 @@
+from __future__ import absolute_import
+
+__all__ = ['CraftProvider']
+
+from .base import Provider
+from freight.models import Deploy
+
+
+class CraftProvider(Provider):
+    def get_options(self):
+        return {
+            'env': {'required': False, 'type': dict},
+        }
+
+    def execute(self, workspace, task):
+        deploy = Deploy.query.filter(Deploy.task_id == task.id).first()
+        return self.run_release(workspace, deploy, task)
+
+    def run_release(self, workspace, deploy, task):
+        # TODO this should be wrapped into a serializer/validator
+        no_merge = bool(task.params.get("noMerge"))
+        no_status_check = bool(task.params.get("noStatusCheck"))
+
+        executable = "craft"
+
+        args = ["publish"]
+        args.append(str(task.params.get("newVersion")))
+        args.append("--no-merge={}".format(str(no_merge).lower()))
+        args.append("--no-status-check={}".format(str(no_status_check).lower()))
+
+        command = "{executable} {args}".format(executable=executable, args=" ".join(args))
+
+        return workspace.run(command, env=task.provider_config.get("env"))

--- a/static/components/CreateBuild.jsx
+++ b/static/components/CreateBuild.jsx
@@ -1,0 +1,116 @@
+import jQuery from "jquery";
+import React from "react";
+
+import { browserHistory } from 'react-router';
+
+import api from "../api";
+import CreateDeploy from "./CreateDeploy";
+import CreateCraftRelease from "./CreateCraftRelease";
+
+
+const TYPE_DEPLOY = 0;
+const TYPE_CRAFT_RELEASE = 1;
+
+
+var CreateBuild = React.createClass({
+
+  contextTypes: {
+    router: React.PropTypes.func
+  },
+
+  getInitialState() {
+    let appList = this.props.appList;
+    let defaultApp = appList.length !== 0 ? appList[0] : null;
+    return {
+      app: defaultApp,
+      submitInProgress: false,
+      submitError: null,
+    };
+  },
+
+  CreateBuildType(props) {
+    const refFunc = instance => { this.child = instance }
+    if (this.state.app.type === TYPE_CRAFT_RELEASE) {
+      // TODO pass props properly
+      return <CreateCraftRelease {...props} ref={refFunc} />;
+    } else {
+      return <CreateDeploy {...props} ref={refFunc} />
+    }
+  },
+
+  onChangeApplication(e) {
+    const val = jQuery(e.target).val();
+    const app = this.props.appList.find(appObject => appObject.name === val);
+    this.setState({
+      app,
+    });
+  },
+
+  onSubmit(e) {
+    e.preventDefault();
+
+    if (this.state.submitInProgress) {
+      return false;
+    }
+
+    this.setState({
+      submitInProgress: true,
+    }, () => {
+      api.request('/deploys/', {
+        method: 'POST',
+        data: this.child.getBuildData(),
+        success: (data) => {
+          this.gotoDeploy(data);
+        },
+        error: (response) => {
+          this.setState({
+            submitError: response.responseJSON['error'],
+            submitInProgress: false,
+          });
+        },
+      });
+    });
+  },
+
+  gotoDeploy(deploy) {
+    let { app, environment, number } = deploy;
+    browserHistory.push(`/deploys/${app.name}/${environment}/${number}`);
+  },
+
+  render() {
+    return (
+      <div className="create-deploy">
+        <div className="section">
+          <div className="section-header">
+            <h2>Create Deploy</h2>
+          </div>
+          {this.state.submitError &&
+            <div className="alert alert-block alert-danger">
+              <strong>Unable to create deploy:</strong>
+              <span>{this.state.submitError}</span>
+            </div>
+          }
+          <form onSubmit={this.onSubmit}>
+            <div className="form-group">
+              <label>Application</label>
+              <select className="form-control"
+                value={this.state.app.name}
+                onChange={this.onChangeApplication}>
+                {this.props.appList.map((app) => {
+                  return <option key={app.name}>{app.name}</option>
+                })}
+              </select>
+            </div>
+            <this.CreateBuildType app={this.state.app} />
+            <div className="submit-group">
+              <button type="submit" className="btn btn-primary"
+                disabled={this.state.submitInProgress}>Ship It!</button>
+            </div>
+          </form>
+        </div>
+      </div>
+    );
+  }
+});
+
+export default CreateBuild;

--- a/static/components/CreateCraftRelease.jsx
+++ b/static/components/CreateCraftRelease.jsx
@@ -1,0 +1,76 @@
+import React from "react";
+
+var CreateCraftRelease = React.createClass({
+
+  getInitialState() {
+    let app = this.props.app || null;
+
+    return {
+      app,
+      env: 'production',
+      ref: 'master',
+      noStatusCheck: false,
+      noMerge: false,
+    };
+  },
+
+  getBuildData() {
+    return {
+      app: this.state.app.name,
+      params: JSON.stringify({
+        newVersion: this.state.newVersion,
+        noStatusCheck: this.state.noStatusCheck,
+        noMerge: this.state.noMerge,
+      }),
+    }
+  },
+
+  render() {
+    return (
+      <div>
+        <div className="form-group">
+          <label>New version</label>
+          <input type="text" className="form-control"
+            pattern="^\s*\d+\.[\d.]+\d(-\w+)?\s*$"
+            onChange={this.onChangeNewVersion}
+            placeholder="e.g. 2.3.4"
+            required />
+        </div>
+        <div className="checkbox">
+          <label>
+            <input type="checkbox"
+              onChange={this.onChangeNoStatusCheck} />
+            Do not check build status
+          </label>
+        </div>
+        <div className="checkbox">
+          <label>
+            <input type="checkbox"
+              onChange={this.onChangeNoMergeBranch} />
+            Do not merge release branch after publishing
+        </label>
+        </div>
+      </div>
+    );
+  },
+
+  onChangeNewVersion(e) {
+    this.setState({
+      newVersion: e.target.value,
+    });
+  },
+
+  onChangeNoStatusCheck(e) {
+    this.setState({
+      noStatusCheck: e.target.checked,
+    });
+  },
+
+  onChangeNoMergeBranch(e) {
+    this.setState({
+      noMerge: e.target.checked,
+    });
+  },
+});
+
+export default CreateCraftRelease;

--- a/static/components/CreateDeploy.jsx
+++ b/static/components/CreateDeploy.jsx
@@ -1,47 +1,52 @@
 import jQuery from "jquery";
 import React from "react";
-import Router from "react-router";
-
-import api from "../api";
-
-import { browserHistory } from 'react-router';
 
 var CreateDeploy = React.createClass({
 
-  contextTypes: {
-    router: React.PropTypes.func
-  },
-
   getInitialState() {
-    let appList    = this.props.appList;
-    let defaultApp = appList.length !== 0 ? appList[0] : null;
-    let defaultEnv = defaultApp ? Object.keys(defaultApp.environments)[0] : null;
-    let envMap     = defaultApp ? defaultApp.environments : {};
+    let app = this.props.app || null;
+    let defaultEnv = app ? Object.keys(app.environments)[0] : null;
+    let envMap = app ? app.environments : {};
     let defaultRef = defaultEnv ? envMap[defaultEnv].defaultRef : 'master';
 
     return {
-      app: defaultApp ? defaultApp.name : null,
+      app,
       env: defaultEnv ? defaultEnv.name : null,
       envMap: envMap,
       ref: defaultRef,
-      submitInProgress: false,
-      submitError: null,
     };
   },
 
-  onChangeApplication(e) {
-    let val    = jQuery(e.target).val();
-    let envMap = val ? this.props.appList.filter((app) => {
-      return app.name === val;
-    })[0].environments || {} : {};
-    let envList = Object.keys(envMap);
-    let env     = envList.length ? envList[0] : null;
-    this.setState({
-      app: val,
-      envMap: envMap,
-      env: env,
-      ref: env ? env.defaultRef : 'master',
-    });
+  getBuildData() {
+    return {
+      app: this.state.app.name,
+      env: this.state.env,
+      ref: this.state.ref,
+      params: this.state.params,
+    }
+  },
+
+  render() {
+    return (
+      <div>
+        <div className="form-group">
+          <label>Environment</label>
+          <select className="form-control"
+            value={this.state.env}
+            onChange={this.onChangeEnvironment}>
+            {Object.keys(this.state.envMap).map((env) => {
+              return <option key={env}>{env}</option>
+            })}
+          </select>
+        </div>
+        <div className="form-group">
+          <label>Ref</label>
+          <input type="text" className="form-control"
+            onChange={this.onChangeRef}
+            placeholder="e.g. master" value={this.state.ref} />
+        </div>
+      </div>
+    );
   },
 
   onChangeEnvironment(e) {
@@ -58,91 +63,6 @@ var CreateDeploy = React.createClass({
       ref: e.target.value,
     });
   },
-
-  onSubmit(e) {
-    e.preventDefault();
-
-    if (this.state.submitInProgress) {
-      return false;
-    }
-
-    this.setState({
-      submitInProgress: true,
-    }, () => {
-      api.request('/deploys/', {
-        method: 'POST',
-        data: {
-          app: this.state.app,
-          env: this.state.env,
-          ref: this.state.ref
-        },
-        success: (data) => {
-          this.gotoDeploy(data);
-        },
-        error: (response) => {
-          this.setState({
-            submitError: response.responseJSON['error'],
-            submitInProgress: false,
-          });
-        },
-      });
-    });
-  },
-
-  gotoDeploy(deploy) {
-    let {app, environment, number} = deploy;
-    browserHistory.push(`/deploys/${app.name}/${environment}/${number}`);
-  },
-
-  render() {
-    return (
-      <div className="create-deploy">
-        <div className="section">
-          <div className="section-header">
-            <h2>Create Deploy</h2>
-          </div>
-          {this.state.submitError &&
-            <div className="alert alert-block alert-danger">
-              <strong>Unable to create deploy:</strong>
-              <span>{this.state.submitError}</span>
-            </div>
-          }
-          <form onSubmit={this.onSubmit}>
-            <div className="form-group">
-              <label>Application</label>
-              <select className="form-control"
-                      value={this.state.app}
-                      onChange={this.onChangeApplication}>
-                {this.props.appList.map((app) => {
-                  return <option key={app.name}>{app.name}</option>
-                })}
-              </select>
-            </div>
-            <div className="form-group">
-              <label>Environment</label>
-              <select className="form-control"
-                      value={this.state.env}
-                      onChange={this.onChangeEnvironment}>
-                {Object.keys(this.state.envMap).map((env) => {
-                  return <option key={env}>{env}</option>
-                })}
-              </select>
-            </div>
-            <div className="form-group">
-              <label>Ref</label>
-              <input type="text" className="form-control"
-                     onChange={this.onChangeRef}
-                     placeholder="e.g. master" value={this.state.ref} />
-            </div>
-            <div className="submit-group">
-              <button type="submit" className="btn btn-primary"
-                      disabled={this.state.submitInProgress}>Ship It!</button>
-            </div>
-          </form>
-        </div>
-      </div>
-    );
-  }
 });
 
 export default CreateDeploy;

--- a/static/routes.jsx
+++ b/static/routes.jsx
@@ -1,9 +1,9 @@
 import React from "react";
-import {Route, IndexRoute} from "react-router";
+import { Route, IndexRoute } from "react-router";
 
 import AppDetails from "./components/AppDetails";
 import AppSettings from "./components/AppSettings";
-import CreateDeploy from "./components/CreateDeploy";
+import CreateBuild from "./components/CreateBuild";
 import Layout from "./components/Layout";
 import Overview from "./components/Overview";
 import RouteNotFound from "./components/RouteNotFound";
@@ -13,15 +13,15 @@ var routes = () => {
   return (
     <Route exact path="/" component={Layout}>
       <IndexRoute component={Overview} />
-      <Route path="/deploy" component={CreateDeploy} />
+      <Route path="/deploy" component={CreateBuild} />
       <Route path="/tasks/:app/:env/:number" component={TaskDetails} />
       <Route path="/deploys/:app/:env/:number" component={TaskDetails} />
       <Route path="/:app/settings" component={AppSettings} />
       <Route path="/:app/:env/:number" component={TaskDetails} />
       <Route path="/:app" component={AppDetails} />
       <Route
-       path="*"
-       component={RouteNotFound} />
+        path="*"
+        component={RouteNotFound} />
     </Route>
   );
 };


### PR DESCRIPTION
This is a POC (no tests, not ready for production) of having support for parameterized builds in Freight. As an example, I added a new provider for [craft](https://github.com/getsentry/craft), but eventually the goal is to have a universal approach for defining jobs and their parameters. 

We don't want to amend database schema every time we add a new type of job with different arguments (e.g. for deploys we have environment and ref, for `craft` -- version and a bunch of boolean flags, etc.), so probably it makes sense to store job configurations as schemaless objects.

What's missing:
* Dynamic UI/configuration: we want to define job parameters for every build type, and then dynamically render the "new build" form with all necessary inputs (text inputs, checkboxes, etc.)

Demo:

![freight_craft](https://user-images.githubusercontent.com/1120468/44601501-fd5a5700-a7dc-11e8-834e-7d023f335d53.gif)


