### PR TITLE
ref(cloudbuild): use branch name instead of 'latest'

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -4,7 +4,7 @@ steps:
     args:
       [
         "-c",
-        "docker pull us.gcr.io/$PROJECT_ID/freight:latest || true"
+        "docker pull us.gcr.io/$PROJECT_ID/freight:master || true"
       ]
 
   - name: "gcr.io/cloud-builders/docker"
@@ -12,15 +12,15 @@ steps:
       [
         "build",
         "--pull",
-        "-t", "us.gcr.io/$PROJECT_ID/freight:latest",
+        "-t", "us.gcr.io/$PROJECT_ID/freight:master",
         "-t", "us.gcr.io/$PROJECT_ID/freight:$COMMIT_SHA",
-        "--cache-from", "us.gcr.io/$PROJECT_ID/freight:latest",
+        "--cache-from", "us.gcr.io/$PROJECT_ID/freight:master",
         ".",
       ]
 
 images:
   [
     "us.gcr.io/$PROJECT_ID/freight:$COMMIT_SHA",
-    "us.gcr.io/$PROJECT_ID/freight:latest",
+    "us.gcr.io/$PROJECT_ID/freight:$BRANCH_NAME",
   ]
 timeout: 60m


### PR DESCRIPTION
this is potentially breaking anywhere someone uses 'latest', so we'll have to make some changes in config management to use 'master' instead.

no urgency on this at all.  just ran into an edge case where it was hard to test a PR branch.