### PR TITLE
provider: Add pipeline provider

### DIFF
--- a/freight/providers/__init__.py
+++ b/freight/providers/__init__.py
@@ -1,9 +1,9 @@
 from .manager import ProviderManager
-from .kubernetes import KubernetesProvider
+from .pipeline import PipelineProvider
 from .shell import ShellProvider
 
 manager = ProviderManager()
-manager.add("kubernetes", KubernetesProvider)
+manager.add("pipeline", PipelineProvider)
 manager.add("shell", ShellProvider)
 
 get = manager.get

--- a/freight/providers/__init__.py
+++ b/freight/providers/__init__.py
@@ -1,7 +1,9 @@
 from .manager import ProviderManager
+from .kubernetes import KubernetesProvider
 from .shell import ShellProvider
 
 manager = ProviderManager()
+manager.add("kubernetes", KubernetesProvider)
 manager.add("shell", ShellProvider)
 
 get = manager.get

--- a/freight/providers/kubernetes.py
+++ b/freight/providers/kubernetes.py
@@ -1,0 +1,207 @@
+__all__ = ["KubernetesProvider"]
+
+from time import sleep
+from functools import partial
+from dataclasses import dataclass, asdict
+
+from kubernetes import client
+from kubernetes.config import new_client_from_config, ConfigException
+
+from .base import Provider
+from freight.models import App, Deploy
+
+
+@dataclass(frozen=True)
+class TaskContext:
+    id: str
+    date_created: str
+    name: str
+    environment: str
+    sha: str
+    prev_sha: str
+    ref: str
+
+
+class KubernetesProvider(Provider):
+    def get_options(self):
+        return {
+            "steps": {"required": True, "type": list},
+            "context": {"required": False, "type": str},
+            "credentials": {"required": False, "type": dict},
+        }
+
+    def get_config(self, workspace, task):
+        # from yaml import safe_load
+        # TODO(mattrobenolt): Load and merge config (.freight.yml) from
+        # within the workspace, so a config could be left out entirely.
+        return {**task.provider_config, **{}}
+
+    def execute(self, workspace, task):
+        deploy = Deploy.query.filter(Deploy.task_id == task.id).first()
+        return self.execute_deploy(workspace, deploy, task)
+
+    def execute_deploy(self, workspace, deploy, task):
+        app = App.query.get(task.app_id)
+        prev_sha = app.get_previous_sha(deploy.environment, current_sha=task.sha)
+
+        config = self.get_config(workspace, task)
+        api_client = load_credentials(config)
+
+        task_context = TaskContext(
+            str(deploy.id),
+            str(task.date_created),
+            app.name,
+            deploy.environment,
+            task.sha,
+            prev_sha or "",
+            task.ref,
+        )
+
+        for step in config["steps"]:
+            run_step(step, api_client, task_context)
+
+
+def load_credentials(config):
+    try:
+        return new_client_from_config(context=config["context"])
+    except KeyError:
+        pass
+
+    try:
+        credentials = config["credentials"]
+    except KeyError:
+        return
+
+    assert credentials["kind"] == "gcloud"
+
+    return load_credentials_gcloud(credentials)
+
+
+def load_credentials_gcloud(credentials):
+    from subprocess import check_call, DEVNULL
+
+    cluster = credentials["cluster"]
+    project = credentials["project"]
+    zone = credentials["zone"]
+
+    context = f"gke_{project}_{zone}_{cluster}"
+
+    try:
+        return new_client_from_config(context=context)
+    except ConfigException:
+        pass
+
+    check_call(
+        [
+            "gcloud",
+            "container",
+            "clusters",
+            "get-credentials",
+            cluster,
+            "--zone",
+            zone,
+            "--project",
+            project,
+        ],
+        stdout=DEVNULL,
+        stderr=DEVNULL,
+    )
+
+    return new_client_from_config(context=context)
+
+
+def run_step(step, api_client, task):
+    assert step["kind"] == "Deployment"
+    watchers = run_step_deployment(step, api_client, task)
+    changes = bool(watchers)
+    while watchers:
+        for watcher, state in watchers:
+            status, success = watcher()
+            last_status = state.get("status", None)
+            if last_status is None or status != last_status:
+                print(status)
+                state["status"] = status
+            if success:
+                watchers.remove((watcher, state))
+        sleep(0.5)
+    return changes
+
+
+def run_step_deployment(step, api_client, task):
+    api = client.AppsV1beta1Api(api_client)
+
+    selector = step["selector"]
+    selector.setdefault("namespace", "default")
+    containers = step["containers"]
+
+    watchers = []
+
+    for deployment in api.list_namespaced_deployment(**selector).items:
+        namespace = deployment.metadata.name
+        name = deployment.metadata.name
+        changes = False
+        for container in deployment.spec.template.spec.containers:
+            for c in containers:
+                if container.name == c["name"]:
+                    container.image = c["image"].format(**asdict(task))
+                    changes = True
+        if changes:
+            if deployment.metadata.annotations is None:
+                deployment.metadata.annotations = {}
+            if deployment.spec.template.metadata.annotations is None:
+                deployment.spec.template.metadata.annotations = {}
+            for k, v in asdict(task).items():
+                deployment.metadata.annotations[f"freight.sentry.io/{k}"] = v
+                deployment.spec.template.metadata.annotations[f"freight.sentry.io/{k}"] = v
+
+            resp = api.patch_namespaced_deployment(
+                name=deployment.metadata.name,
+                namespace=deployment.metadata.namespace,
+                body=deployment,
+            )
+
+            watchers.append(
+                (
+                    partial(
+                        rollout_status_deployment,
+                        api,
+                        resp.metadata.name,
+                        resp.metadata.namespace,
+                        resp.metadata.generation,
+                    ),
+                    {},  # empty state dict for this rollout
+                )
+            )
+
+    return watchers
+
+
+def rollout_status_deployment(api, name, namespace, generation):
+    # TODO(mattrobenolt): Need to handle error state better/at all.
+    # Right now, if say, it's an ErrImagePull or something, it just will sit
+    # here forever with no reason why. Need to figure out how to get
+    # this reason becasue there are many reasons why it could fail.
+    deployment = api.read_namespaced_deployment(name=name, namespace=namespace)
+    if generation <= deployment.status.observed_generation:
+        replicas = deployment.spec.replicas
+        updated_replicas = deployment.status.updated_replicas or 0
+        available_replicas = deployment.status.available_replicas or 0
+
+        if updated_replicas < replicas:
+            return (
+                f"Waiting for deployment {repr(name)} rollout to finish: {updated_replicas} out of {replicas} new replicas have been updated...",
+                False,
+            )
+        if replicas > updated_replicas:
+            return (
+                f"Waiting for deployment {repr(name)} rollout to finish: {replicas-updated_replicas} old replicas are pending termination...",
+                False,
+            )
+        if available_replicas < updated_replicas:
+            return (
+                f"Waiting for deployment {repr(name)} rollout to finish: {available_replicas} of {updated_replicas} updated replicas are available...",
+                False,
+            )
+        return f"Deployment {repr(name)} successfully rolled out", True
+
+    return f"Waiting for deployment {repr(name)} spec update to be observed...", False

--- a/freight/providers/pipeline.py
+++ b/freight/providers/pipeline.py
@@ -41,6 +41,10 @@ class StepFailed(Exception):
     pass
 
 
+class AuthenticationError(Exception):
+    pass
+
+
 class PipelineProvider(Provider):
     def get_options(self):
         return {
@@ -91,6 +95,7 @@ class PipelineProvider(Provider):
 
 
 def load_kube_credentials(config: dict) -> client.ApiClient:
+    # If a context is specified, attempt to use this first.
     try:
         return new_client_from_config(context=config["context"])
     except KeyError:
@@ -99,14 +104,18 @@ def load_kube_credentials(config: dict) -> client.ApiClient:
     try:
         credentials = config["credentials"]
     except KeyError:
-        return
+        raise AuthenticationError("Missing kubernetes context.")
 
-    assert credentials["kind"] == "gcloud"
+    if credentials["kind"] not in ("gcloud",):
+        raise AuthenticationError(f"Unknown kubernetes kind: {credentials['kind']}")
 
     return load_kube_credentials_gcloud(credentials)
 
 
 def load_kube_credentials_gcloud(credentials: dict) -> client.ApiClient:
+    # Try to pull credentials from gcloud, but first checking if there
+    # is a context, using their auto generated naming scheme, to avoid
+    # calling `gcloud` every time, if we've already authed before.
     from subprocess import check_call, DEVNULL
 
     cluster = credentials["cluster"]
@@ -139,10 +148,10 @@ def load_kube_credentials_gcloud(credentials: dict) -> client.ApiClient:
     return new_client_from_config(context=context)
 
 
-def run_step(step: dict, context: PipelineContext) -> bool:
-    assert step["kind"] in ("Shell", "KubernetesDeployment", "KubernetesJob"), step[
-        "kind"
-    ]
+def run_step(step: dict, context: PipelineContext):
+    if step["kind"] not in ("Shell", "KubernetesDeployment", "KubernetesJob"):
+        raise StepFailed(f"Unknown step kind: {step['kind']}")
+
     watchers = {
         "Shell": run_step_shell,
         "KubernetesDeployment": run_step_deployment,
@@ -150,7 +159,12 @@ def run_step(step: dict, context: PipelineContext) -> bool:
     }[step["kind"]](step, context)
     if not watchers:
         return
-    changes = bool(watchers)
+
+    # Steps may return a list of "watchers". A watcher is meant to
+    # watch over an async operation and wait until they are finished.
+
+    # Iterate over all watchers, waiting for state to be True, and
+    # printing out their status until they finish.
     while watchers:
         for watcher, state in watchers:
             status, success = watcher()
@@ -163,12 +177,12 @@ def run_step(step: dict, context: PipelineContext) -> bool:
             if success:
                 watchers.remove((watcher, state))
                 if not watchers:
-                    break
+                    return
         sleep(0.5)
-    return changes
 
 
 def run_step_deployment(step: dict, context: PipelineContext) -> List[Callable]:
+    # Execute a Kubernetes Deployment
     context.workspace.log.info(f"Running Deployment: {repr(step)}")
 
     api = client.AppsV1beta1Api(context.kube.client)
@@ -179,6 +193,22 @@ def run_step_deployment(step: dict, context: PipelineContext) -> List[Callable]:
 
     watchers = []
 
+    # First, we collect a list of Deployments from kubernetes based on
+    # the `selector`. This may return 0, 1, or many Deployments.
+
+    # For each Deployment, we scan for matching containers by name. So
+    # it's possible that a Deployment matches a selector, but does not
+    # have a container that matches. This is expected behavior, and moves
+    # along gracefully. This allows a wider selector, and refine it by only
+    # updating containers that match.
+
+    # When a container is found within a Deployment, we patch the `image`.
+    # This is roughly equivalent to doing `kubectl set image ...`. We also
+    # patch in metadata about the deploy itself in the annotations on both
+    # the Deployment and the PodTemplate. This decision was made so that
+    # a bump of the annotations would cause a rolling restart of the service,
+    # even if the image doesn't change. This means a re-deploy of a service
+    # is not entirely a no-op, but will restart all Deployments still.
     for deployment in api.list_namespaced_deployment(**selector).items:
         namespace = deployment.metadata.name
         name = deployment.metadata.name
@@ -188,6 +218,10 @@ def run_step_deployment(step: dict, context: PipelineContext) -> List[Callable]:
                 if container.name == c["name"]:
                     container.image = c["image"]
                     changes = True
+
+        # If there are any changes at all in this deployment, we need
+        # to patch in our freight annotations, and trigger the PATCH call,
+        # as well as set up the watcher to keep track of its rollout.
         if changes:
             if deployment.metadata.annotations is None:
                 deployment.metadata.annotations = {}
@@ -221,11 +255,14 @@ def run_step_deployment(step: dict, context: PipelineContext) -> List[Callable]:
 
 
 def run_step_shell(step: dict, context: PipelineContext):
+    # Execute a shell command within our workspace
     command = format_task(step["command"], context.task)
     context.workspace.run(command, env=step.get("env"))
 
 
 def format_task(data, task: TaskContext):
+    # Recursively formatting strings that may
+    # contain taskcontext vars.
     if isinstance(data, str):
         return data.format(**asdict(task))
     if isinstance(data, list):
@@ -236,6 +273,13 @@ def format_task(data, task: TaskContext):
 
 
 def make_job_spec(step: dict, task: TaskContext) -> dict:
+    # Translate our customer KubernetesJob, which is just a subset of
+    # allowed Kubernetes Job configs, into a real Job spec. This subset is
+    # done so that we can control better what a Job means, including an
+    # auto generated name, and enforcing the use of a single container.
+    # The properties allowed to be defined are:
+    #   name*, namespace, image*, args, env, volumeMounts, resources, volumes
+    # * = required
     return {
         "kind": "Job",
         "metadata": {
@@ -265,6 +309,21 @@ def make_job_spec(step: dict, task: TaskContext) -> dict:
 
 
 def run_step_job(step: dict, context: PipelineContext):
+    # Run a one-off Job in Kubernetes and track it through to completion.
+    # Running a job in Kubernetes is a bit non-trivial, and involves the
+    # following:
+    #  * Create the Job spec
+    #  * Querying for the Pod created by the Job until it is in a state
+    #    other than Pending. This involves using the label: `job-name={jobname}`
+    #  * Once we're past Pending, the Pod is either in Running, Succeeded,
+    #    or Failed state. At this point, we read it's container logs until
+    #    the pod exits.
+    #  * Once the Pod exits, and we have fully read the logs, we are safe
+    #    to proceed with reporting the step as success or failure.
+    #  * When all said and done, we delete the Job, with it's children Pods
+    #    to avoid these collecting and hanging around. It's still possible
+    #    a Job may get orphaned, but these will eventually get cleaned up by
+    #    Kubernetes, so it's not a huge deal if this happens.
     context.workspace.log.info(f"Running Job: {repr(step)}")
 
     job_spec = make_job_spec(step, context.task)
@@ -277,6 +336,7 @@ def run_step_job(step: dict, context: PipelineContext):
     )
     pod_name = None
     try:
+        # Find our Pod that is spawned from this Job
         pods = (
             client.CoreV1Api(context.kube.client)
             .list_namespaced_pod(namespace=namespace, label_selector=f"job-name={name}")
@@ -285,17 +345,27 @@ def run_step_job(step: dict, context: PipelineContext):
         assert len(pods) == 1, len(pods)
         pod_name = pods[0].metadata.name
         context.workspace.log.info(f"Waiting for Pod {pod_name}")
+
+        # Now we begin our loop and shitty state machine
         read_logs = False
         while True:
             pod = client.CoreV1Api(context.kube.client).read_namespaced_pod(
                 namespace=namespace, name=pod_name
             )
+            # If we have successfully read our logs, we're ready to report
+            # status.
             if read_logs:
                 if pod.status.phase == "Failed":
                     raise StepFailed("Failed")
-                break
+                return
 
             if pod.status.phase == "Pending":
+                # If we are in a Pending state, we need to also check
+                # if we're in the ContainerCreating phase of the container inside.
+                # For any other event, like, an ErrImagePull, the Pod will
+                # forever be left in Pending, but the container inside has errored.
+                # So the only valid state to continue waiting is ContainerCreating.
+                # Any other state is considered a failure.
                 if (
                     pod.status.container_statuses[0].state.waiting.reason
                     == "ContainerCreating"
@@ -308,6 +378,17 @@ def run_step_job(step: dict, context: PipelineContext):
                     )
 
             if pod.status.phase in ("Running", "Succeeded", "Failed"):
+                # At this point, our Pod has either begun running or finished.
+                # For any case, we want to begin to tail (follow) logs until the
+                # Pod exits. This works for both a running Pod, and a finished Pod
+                # the same.
+
+                # HACK: When _preload_context is passed, this causes the kubernetes
+                # API here to return a urllib3 HTTPResponse object directly ready
+                # to be streamed, so the following use of `resp.stream()` and
+                # `resp.release_conn()` are just standard urllib3 behaviors.
+                # This is entirely undocumented behavior afaik, and the only way to
+                # actually get `follow=True` to work.
                 resp = client.CoreV1Api(context.kube.client).read_namespaced_pod_log(
                     namespace=namespace,
                     name=pod_name,
@@ -323,6 +404,10 @@ def run_step_job(step: dict, context: PipelineContext):
                 sys.stdout.write("\n")
                 sys.stdout.flush()
                 read_logs = True
+                # When finished reading logs, we need to loop back around
+                # so we can query the final state of the Pod, in the case that
+                # it was Running when we got here, we don't know if it succeeded
+                # or failed.
     finally:
         context.workspace.log.info(f"Deleting Job {namespace}/{name}")
         client.BatchV1Api(context.kube.client).delete_namespaced_job(
@@ -333,6 +418,8 @@ def run_step_job(step: dict, context: PipelineContext):
 def rollout_status_deployment(
     api: client.AppsV1beta1Api, name: str, namespace: str, generation: int
 ) -> Tuple[str, bool]:
+    # tbh this is mostly ported from Go into Python from:
+    # https://github.com/kubernetes/kubernetes/blob/master/pkg/kubectl/rollout_status.go#L76-L92
     deployment = api.read_namespaced_deployment(name=name, namespace=namespace)
     if generation <= deployment.status.observed_generation:
         replicas = deployment.spec.replicas

--- a/freight/providers/pipeline.py
+++ b/freight/providers/pipeline.py
@@ -2,7 +2,7 @@ __all__ = ["PipelineProvider"]
 
 import sys
 from time import sleep, time
-from typing import Optional, List, Callable
+from typing import Optional, List, Callable, Tuple
 from functools import partial
 from dataclasses import dataclass, asdict
 
@@ -140,7 +140,9 @@ def load_kube_credentials_gcloud(credentials: dict) -> client.ApiClient:
 
 
 def run_step(step: dict, context: PipelineContext) -> bool:
-    assert step["kind"] in ("Shell", "KubernetesDeployment", "KubernetesJob"), step["kind"]
+    assert step["kind"] in ("Shell", "KubernetesDeployment", "KubernetesJob"), step[
+        "kind"
+    ]
     watchers = {
         "Shell": run_step_shell,
         "KubernetesDeployment": run_step_deployment,
@@ -328,7 +330,9 @@ def run_step_job(step: dict, context: PipelineContext):
         )
 
 
-def rollout_status_deployment(api, name, namespace, generation):
+def rollout_status_deployment(
+    api: client.AppsV1beta1Api, name: str, namespace: str, generation: int
+) -> Tuple[str, bool]:
     deployment = api.read_namespaced_deployment(name=name, namespace=namespace)
     if generation <= deployment.status.observed_generation:
         replicas = deployment.spec.replicas

--- a/freight/providers/pipeline.py
+++ b/freight/providers/pipeline.py
@@ -329,10 +329,6 @@ def run_step_job(step: dict, context: PipelineContext):
 
 
 def rollout_status_deployment(api, name, namespace, generation):
-    # TODO(mattrobenolt): Need to handle error state better/at all.
-    # Right now, if say, it's an ErrImagePull or something, it just will sit
-    # here forever with no reason why. Need to figure out how to get
-    # this reason becasue there are many reasons why it could fail.
     deployment = api.read_namespaced_deployment(name=name, namespace=namespace)
     if generation <= deployment.status.observed_generation:
         replicas = deployment.spec.replicas

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,8 +7,10 @@ flask-sslify>=0.1.5,<0.2.0
 flask-sqlalchemy>=2.3.2,<2.4
 flask-redis>=0.3,<0.4
 flask-restful>=0.3.7,<0.4.0
+kubernetes==9.0.0
 oauth2client>=4.1.3,<4.2
 psycopg2-binary>=2.8.2,<2.9
+PyYAML==5.1
 raven==6.10.0
 redis>=3.2.1,<3.3
 requests>=2.21,<2.22


### PR DESCRIPTION
This change provides a new pipeline provider. A pipeline provider is comprised of steps. The 3 steps being implemented currently are `Shell`, `KubernetesJob`, and `KubernetesDeployment`.

Each step is run sequentially, and if applicable, within a step, in parallel. If any step fails, the rest of the pipeline does not continue.

## Kubernetes

There is a top level, optional, `kubernetes` configuration block. This controls how to fetch kubernetes credentials, or which context to use for authentication. One of either `context` or `credentials` may be defined, but not both. At the moment, `credentials` only supports sourcing from `gcloud`.

## Steps

### Shell

This mirrors behavior of our current `shell` provider, just as a step. No new behavior.

### KubernetesJob

This provides the ability to run a one-off `Job` spec in Kubernetes. The struct here is pared down a bit to not support the full breadth of a `Job` in Kubernetes, but just a subset in order to provide more control.

### KubernetesDeploy

This effectively is running `kubectl set image ...` and monitors the rollout of this change. You can target multiple `Deployments` in Kubernetes by the `selector` block, and `containers` block.

## Example

```
"provider": "pipeline",
"provider_config": {
    "steps": [
      {
        "kind": "Shell", 
        "command": "echo ref={ref} environment={environment}"
      }, 
      {
        "kind": "KubernetesJob", 
        "args": [
          "bash", 
          "-c", 
          "for i in {{1..30}}; do echo hello $i && sleep 0.5; done"
        ], 
        "name": "upgrade", 
        "image": "debian"
      }, 
      {
        "kind": "KubernetesDeployment", 
        "containers": [
          {
            "image": "sentry:{sha}", 
            "name": "sentry"
          }
        ], 
        "selector": {
          "label_selector": "app=sentry,tier=some-tier,environment={environment}"
        }
      }
    ], 
    "kubernetes": {
      "credentials": {
        "kind": "gcloud", 
        "project": "mattrobenolt-xxx", 
        "cluster": "xxx", 
        "zone": "us-west1-c"
      }
    }
  }, 
```