### PR TITLE
fix(provider): fix rollout_status_deployment

### DIFF
--- a/freight/providers/pipeline.py
+++ b/freight/providers/pipeline.py
@@ -576,6 +576,13 @@ def rollout_status_deployment(
     if deployment.metadata.generation > deployment.status.observed_generation:
         return f"Waiting for deployment {repr(name)} spec update to be observed...", False
 
+    # TimedOutReason is added in a deployment when its newest replica set
+    # fails to show any progress within the given deadline (progressDeadlineSeconds).
+    for condition in deployment.status.conditions:
+        if condition.type == "Progressing":
+            if condition.reason == "ProgressDeadlineExceeded":
+                return f"deployment {repr(name)} exceeded its progress deadline", False
+
     spec_replicas = deployment.spec.replicas
     status_replicas = deployment.status.replicas
     updated_replicas = deployment.status.updated_replicas or 0

--- a/freight/providers/pipeline.py
+++ b/freight/providers/pipeline.py
@@ -357,7 +357,6 @@ def run_step_deployment(
                         api,
                         resp.metadata.name,
                         resp.metadata.namespace,
-                        resp.metadata.generation,
                     ),
                     {},  # empty state dict for this rollout
                 )
@@ -569,12 +568,12 @@ def run_step_cronjob(
 
 
 def rollout_status_deployment(
-    api: client.AppsV1beta1Api, name: str, namespace: str, generation: int
+    api: client.AppsV1beta1Api, name: str, namespace: str,
 ) -> Tuple[str, bool]:
     # tbh this is mostly ported from Go into Python from:
     # https://github.com/kubernetes/kubernetes/blob/master/pkg/kubectl/rollout_status.go#L76-L92
     deployment = api.read_namespaced_deployment(name=name, namespace=namespace)
-    if generation <= deployment.status.observed_generation:
+    if deployment.metadata.generation <= deployment.status.observed_generation:
         replicas = deployment.spec.replicas
         updated_replicas = deployment.status.updated_replicas or 0
         available_replicas = deployment.status.available_replicas or 0

--- a/freight/providers/pipeline.py
+++ b/freight/providers/pipeline.py
@@ -573,29 +573,29 @@ def rollout_status_deployment(
     # tbh this is mostly ported from Go into Python from:
     # https://github.com/kubernetes/kubernetes/blob/master/pkg/kubectl/rollout_status.go#L76-L92
     deployment = api.read_namespaced_deployment(name=name, namespace=namespace)
-    if deployment.metadata.generation <= deployment.status.observed_generation:
-        replicas = deployment.spec.replicas
-        updated_replicas = deployment.status.updated_replicas or 0
-        available_replicas = deployment.status.available_replicas or 0
+    if deployment.metadata.generation > deployment.status.observed_generation:
+        return f"Waiting for deployment {repr(name)} spec update to be observed...", False
 
-        if updated_replicas < replicas:
-            return (
-                f"Waiting for deployment {repr(name)} rollout to finish: {updated_replicas} out of {replicas} new replicas have been updated...",
-                False,
-            )
-        if replicas > updated_replicas:
-            return (
-                f"Waiting for deployment {repr(name)} rollout to finish: {replicas-updated_replicas} old replicas are pending termination...",
-                False,
-            )
-        if available_replicas < updated_replicas:
-            return (
-                f"Waiting for deployment {repr(name)} rollout to finish: {available_replicas} of {updated_replicas} updated replicas are available...",
-                False,
-            )
-        return f"Deployment {repr(name)} successfully rolled out", True
+    replicas = deployment.spec.replicas
+    updated_replicas = deployment.status.updated_replicas or 0
+    available_replicas = deployment.status.available_replicas or 0
 
-    return f"Waiting for deployment {repr(name)} spec update to be observed...", False
+    if updated_replicas < replicas:
+        return (
+            f"Waiting for deployment {repr(name)} rollout to finish: {updated_replicas} out of {replicas} new replicas have been updated...",
+            False,
+        )
+    if replicas > updated_replicas:
+        return (
+            f"Waiting for deployment {repr(name)} rollout to finish: {replicas-updated_replicas} old replicas are pending termination...",
+            False,
+        )
+    if available_replicas < updated_replicas:
+        return (
+            f"Waiting for deployment {repr(name)} rollout to finish: {available_replicas} of {updated_replicas} updated replicas are available...",
+            False,
+        )
+    return f"Deployment {repr(name)} successfully rolled out", True
 
 
 def merge_dicts(a: dict, b: dict) -> dict:

--- a/freight/providers/pipeline.py
+++ b/freight/providers/pipeline.py
@@ -576,18 +576,19 @@ def rollout_status_deployment(
     if deployment.metadata.generation > deployment.status.observed_generation:
         return f"Waiting for deployment {repr(name)} spec update to be observed...", False
 
-    replicas = deployment.spec.replicas
+    spec_replicas = deployment.spec.replicas
+    status_replicas = deployment.status.replicas
     updated_replicas = deployment.status.updated_replicas or 0
     available_replicas = deployment.status.available_replicas or 0
 
-    if updated_replicas < replicas:
+    if updated_replicas < spec_replicas:
         return (
-            f"Waiting for deployment {repr(name)} rollout to finish: {updated_replicas} out of {replicas} new replicas have been updated...",
+            f"Waiting for deployment {repr(name)} rollout to finish: {updated_replicas} out of {spec_replicas} new replicas have been updated...",
             False,
         )
-    if replicas > updated_replicas:
+    if status_replicas > updated_replicas:
         return (
-            f"Waiting for deployment {repr(name)} rollout to finish: {replicas-updated_replicas} old replicas are pending termination...",
+            f"Waiting for deployment {repr(name)} rollout to finish: {status_replicas-updated_replicas} old replicas are pending termination...",
             False,
         )
     if available_replicas < updated_replicas:


### PR DESCRIPTION
The incorrect replica stats were being used in determining the status string (see 
57168b6).

Reference: https://github.com/kubernetes/kubernetes/blob/75d51896125b1cafd9e995212b02ccda9b8a0aed/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/rollout_status.go#L76

Also, the `ProgressDeadlineExceeded` `Progressing` deployment condition is now recognized.