### PR TITLE
fix(provider): default null value for status_replicas to 0 to avoid TypeError

### DIFF
--- a/freight/providers/pipeline.py
+++ b/freight/providers/pipeline.py
@@ -584,7 +584,7 @@ def rollout_status_deployment(
                 return f"deployment {repr(name)} exceeded its progress deadline", False
 
     spec_replicas = deployment.spec.replicas
-    status_replicas = deployment.status.replicas
+    status_replicas = deployment.status.replicas or 0
     updated_replicas = deployment.status.updated_replicas or 0
     available_replicas = deployment.status.available_replicas or 0
 


### PR DESCRIPTION
It looks like `status_replicas` also is None before it's populated. Unfortunately, [the docs](https://github.com/kubernetes-client/python/blob/master/kubernetes/docs/AppsV1beta1DeploymentStatus.md#appsv1beta1deploymentstatus) don't really make this clear.

Oh yeah, this fix is going to have to also be applied to `st-kube`.

Fixes FREIGHT-QV.