### PR TITLE
fix(cloudbuilder): Allow to filter by image name and SHA

### DIFF
--- a/freight/checks/cloudbuilder.py
+++ b/freight/checks/cloudbuilder.py
@@ -26,7 +26,11 @@ class GCPContainerBuilderCheck(Check):
     required = True
 
     def get_options(self):
-        return {"project": {"required": True}, "oauth_token": {"required": False}}
+        return {
+            "project": {"required": True},
+            "oauth_token": {"required": False},
+            "image_name": {"required": False},
+        }
 
     def check(self, app, sha, config):
         """Check build status
@@ -48,7 +52,16 @@ class GCPContainerBuilderCheck(Check):
                 .decode("utf-8")
             )
 
-        params = {"filter": f'sourceProvenance.resolvedRepoSource.commitSha="{sha}"'}
+        params = {}
+        image_name = config.get("image_name")
+        if image_name is None:
+            # Note: this doesn't work with the new "Cloud Build GitHub App" way of checking out repositories.
+            params["filter"] = f'sourceProvenance.resolvedRepoSource.commitSha="{sha}"'
+        else:
+            # Should work for both cases ("Cloud Build GitHub App" and "GitHub (mirrored)").
+            # This should be working fine Even if "images" contains multiple entries.
+            params["filter"] = f'images="{image_name}:{sha}"'
+
         headers = {
             "Accepts": "application/json",
             "Authorization": f"Bearer {oauth_token}",

--- a/freight/checks/cloudbuilder.py
+++ b/freight/checks/cloudbuilder.py
@@ -59,7 +59,7 @@ class GCPContainerBuilderCheck(Check):
             params["filter"] = f'sourceProvenance.resolvedRepoSource.commitSha="{sha}"'
         else:
             # Should work for both cases ("Cloud Build GitHub App" and "GitHub (mirrored)").
-            # This should be working fine Even if "images" contains multiple entries.
+            # This should be working fine even if "images" contains multiple entries.
             params["filter"] = f'images="{image_name}:{sha}"'
 
         headers = {

--- a/static/tests/__snapshots__/TaskSummary.test.js.snap
+++ b/static/tests/__snapshots__/TaskSummary.test.js.snap
@@ -67,7 +67,7 @@ exports[`TaskSummary Snapshot 1`] = `
           date="2017-07-13T18:30:45.484661Z"
         >
           <time>
-            2 years ago
+            3 years ago
           </time>
         </TimeSince>
          —


### PR DESCRIPTION
There are (at least) two ways how one can add a repo to Cloud Build: "Github (mirrored)" and via "Cloud Build Github App".

![image](https://user-images.githubusercontent.com/1120468/72277352-0fd36b80-3632-11ea-9a03-ba7e51809768.png)

The second way is not supported by Freight at the moment, because `sourceProvenance.resolvedRepoSource.commitSha` does not exist on the build triggered from those repositories:
https://github.com/getsentry/freight/blob/e14c7b0e71e82f82b134401a3cf6c0895b81711c/freight/checks/cloudbuilder.py#L51


This PR adds an (optional) "image_name" attribute that should work for both approaches.
