### PR TITLE
fix: Prefill environment list properly

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "webpack-dev-server": "^3.2.1"
   },
   "volta": {
-    "node": "8.15.1"
+    "node": "8.15.1",
+    "yarn": "1.22.0"
   }
 }

--- a/static/components/CreateDeploy.jsx
+++ b/static/components/CreateDeploy.jsx
@@ -14,16 +14,17 @@ class CreateDeploy extends React.Component {
     super(props);
     const appList = props.appList;
     const defaultApp = appList.length !== 0 ? appList[0] : null;
-    const defaultEnv = defaultApp ? Object.keys(defaultApp.environments)[0] : null;
-    const envMap = defaultApp ? defaultApp.environments : {};
+    const app = props.location.query?.app
+      ? props.location.query.app
+      : defaultApp
+      ? defaultApp.name
+      : null;
+    const defaultEnv = app ? Object.keys(app.environments)[0] : null;
+    const envMap = app ? app.environments : {};
     const defaultRef = defaultEnv ? envMap[defaultEnv].defaultRef : 'master';
 
     this.state = {
-      app: props.location.query?.app
-        ? props.location.query.app
-        : defaultApp
-        ? defaultApp.name
-        : null,
+      app,
       env: defaultEnv ? defaultEnv.name : null,
       envMap,
       ref: defaultRef,

--- a/static/components/CreateDeploy.jsx
+++ b/static/components/CreateDeploy.jsx
@@ -19,13 +19,16 @@ class CreateDeploy extends React.Component {
       : defaultApp
       ? defaultApp.name
       : null;
-    const defaultEnv = app ? Object.keys(app.environments)[0] : null;
-    const envMap = app ? app.environments : {};
-    const defaultRef = defaultEnv ? envMap[defaultEnv].defaultRef : 'master';
+    const envMap = app
+      ? appList.filter(appObj => appObj.name === app)[0].environments || {}
+      : {};
+    const envList = Object.keys(envMap);
+    const env = envList.length ? envList[0] : null;
+    const defaultRef = env ? envMap[env].defaultRef : 'master';
 
     this.state = {
       app,
-      env: defaultEnv ? defaultEnv.name : null,
+      env,
       envMap,
       ref: defaultRef,
       submitInProgress: false,

--- a/static/tests/__snapshots__/CreateDeploy.test.js.snap
+++ b/static/tests/__snapshots__/CreateDeploy.test.js.snap
@@ -64,6 +64,7 @@ exports[`CreateDeploy Snapshot 1`] = `
           <select
             className="form-control"
             onChange={[Function]}
+            value="production"
           >
             <option
               key="production"


### PR DESCRIPTION
When you click on "Deploy" while you're at the app list page (or just open /deploy?app=NAME) , the list of environments is not populated properly because the app name is taken from the query parameters later than necessary.