### PR TITLE
ref: better error message for no contexts

### DIFF
--- a/freight/checks/github.py
+++ b/freight/checks/github.py
@@ -42,7 +42,12 @@ class GitHubContextCheck(Check):
 
         context_list = resp.json()
         if not context_list:
-            raise CheckFailed("No contexts were present in GitHub")
+            raise CheckFailed(
+                "No contexts were present in GitHub. "
+                "This means that no statuses, like CI results, "
+                "were found for the commit. You may want to wait a bit, "
+                "or failing that, deploy a new commit."
+            )
 
         valid_contexts = set()
         for data in context_list:

--- a/freight/checks/github_apps.py
+++ b/freight/checks/github_apps.py
@@ -45,7 +45,12 @@ class GitHubAppsContextCheck(Check):
 
         check_runs_dict = resp.json()
         if not check_runs_dict or not check_runs_dict.get("total_count"):
-            raise CheckFailed("No contexts were present in GitHub")
+            raise CheckFailed(
+                "No contexts were present in GitHub. "
+                "This means that no statuses, like CI results, "
+                "were found for the commit. You may want to wait a bit, "
+                "or failing that, deploy a new commit."
+            )
 
         valid_contexts = set()
         for check_run in check_runs_dict.get("check_runs", []):


### PR DESCRIPTION
I've brought up this concern in the past that the error message isn't helpful. This "contexts" thing is very API-specific, and [it should really be "statuses"](https://developer.github.com/v3/repos/statuses/#list-statuses-for-a-specific-ref), but I didn't feel like renaming a bunch of variables.

It's resurfaced: https://sentry.slack.com/archives/CTJL7358X/p1589575919289000

So, this improves the error message.

Also, not sure if github_apps is needed.
