### PR TITLE
feat(notifier): Make webhook "status" properly more informative

### DIFF
--- a/tests/notifiers/test_webhook.py
+++ b/tests/notifiers/test_webhook.py
@@ -36,6 +36,7 @@ class WebhookNotifierTest(WebhookNotifierBase):
         assert responses.calls[0].request.url == "http://example.com/"
         body = responses.calls[0].request.body
         payload = json.loads(body)
+        assert body["status"] == "finished"
         assert payload
 
     @responses.activate
@@ -55,4 +56,5 @@ class WebhookNotifierTest(WebhookNotifierBase):
         headers = responses.calls[0].request.headers
         assert headers["secret"] == "abcxyz"
         payload = json.loads(body)
+        assert body["status"] == "started"
         assert payload


### PR DESCRIPTION
Status was previously a stringified int representing only the notifier event (started, queued, finished). Updated to now include the deploy result if the event is "finished".