### PR TITLE
fix: Change datetime format in deployment logs to match others

### DIFF
--- a/freight/api/deploy_log.py
+++ b/freight/api/deploy_log.py
@@ -3,11 +3,13 @@ from flask_restful import reqparse
 from freight.api.base import ApiView
 from freight.config import db
 from freight.models import LogChunk
+from freight.api.serializer.base import Serializer
 
 from .deploy_details import DeployMixin
 
 
 class DeployLogApiView(ApiView, DeployMixin):
+    serializer = Serializer()
     get_parser = reqparse.RequestParser()
     get_parser.add_argument("offset", location="args", type=int, default=0)
     get_parser.add_argument("limit", location="args", type=int)
@@ -68,7 +70,7 @@ class DeployLogApiView(ApiView, DeployMixin):
         context = {
             "nextOffset": next_offset,
             "chunks": [
-                {"text": c.text, "date": c.date_created.isoformat()} for c in logchunks
+                {"text": c.text, "date": self.serializer.format_datetime(c.date_created)} for c in logchunks
             ],
         }
 

--- a/static/components/TaskDetails.jsx
+++ b/static/components/TaskDetails.jsx
@@ -225,13 +225,6 @@ const TaskDetails = createReactClass({
         ***********************************************************************/
         this.highLightDiv(time);
 
-        const timer = new Date(logDataResults.timeStamp[j]);
-        const timeMil = timer.getTime();
-        //Multiple by 60000 to convert offset to milliseconds
-        const offset = timer.getTimezoneOffset() * 60000;
-        const timezone = timeMil - offset;
-        const newDate = new Date(timezone);
-
         div.innerHTML = ansi_up.ansi_to_html(
           linkifyUrls(lineItem[j][k], {
             attributes: {
@@ -240,7 +233,8 @@ const TaskDetails = createReactClass({
             },
           })
         );
-        time.innerHTML = format(newDate, 'h:mm:ss aa');
+        const date = new Date(logDataResults.timeStamp[j]);
+        time.innerHTML = format(date, 'h:mm:ss aa');
 
         div.appendChild(time);
         frag.appendChild(div);


### PR DESCRIPTION
Fixes bug with safari reported via @rhcarvalho  https://github.com/getsentry/freight/pull/234#issuecomment-674085791
Use the same dateformat we use in other parts of the api, remove frontend hack.

Not totally sure if that's the right way to access the serializer.