### PR TITLE
build: Upgrade kubernetes dependency to 11.0.0 and update API clients

### DIFF
--- a/freight/providers/pipeline.py
+++ b/freight/providers/pipeline.py
@@ -307,7 +307,7 @@ def run_step_deployment(
     else:
         kube = context.kube
 
-    api = client.AppsV1beta1Api(kube.client)
+    api = client.AppsV1Api(kube.client)
 
     selector = format_task(step["selector"], context.task)
     selector.setdefault("namespace", "default")
@@ -656,7 +656,7 @@ def run_step_cronjob(
 
 
 def rollout_status_deployment(
-    api: client.AppsV1beta1Api,
+    api: client.AppsV1Api,
     name: str,
     namespace: str,
 ) -> Tuple[str, bool]:

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ flask-sslify>=0.1.5,<0.2.0
 flask-sqlalchemy>=2.3.2,<2.4
 flask-redis>=0.3,<0.4
 flask-restful>=0.3.7,<0.4.0
-kubernetes==9.0.0
+kubernetes==11.0.0
 oauth2client>=4.1.3,<4.2
 psycopg2-binary>=2.8.2,<2.9
 PyYAML==5.1


### PR DESCRIPTION
We need this before upgrading K8S masters to 1.16.

More about API deprecations in 1.16: https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/