### PR TITLE
build(ci): Use GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           python-version: '3.8'
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v1
         with:
           node-version: '8'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,18 +9,18 @@ on:
 jobs:
   ci:
     runs-on: ubuntu-16.04
-    # services:
-      # postgres:
-        # image: postgres:9.6
-        # env:
-          # POSTGRES_USER: postgres
-        # ports:
-          # - 5432:5432
+    services:
+      postgres:
+        image: postgres:9.6
+        env:
+          POSTGRES_USER: postgres
+        ports:
+          - 5432:5432
 
-      # redis:
-        # image: redis:5.0-alpine
-        # ports:
-          # - 6379:6379
+      redis:
+        image: redis:5.0-alpine
+        ports:
+          - 6379:6379
 
     steps:
       - uses: actions/checkout@v2
@@ -34,8 +34,6 @@ jobs:
           node-version: '8'
 
       - run: make develop
-
-      - run: docker-compose
 
       - run: |
           psql -c 'create database test_freight;' -U postgres

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,50 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  ci:
+    runs-on: ubuntu-16.04
+    # services:
+      # postgres:
+        # image: postgres:9.6
+        # env:
+          # POSTGRES_USER: postgres
+        # ports:
+          # - 5432:5432
+
+      # redis:
+        # image: redis:5.0-alpine
+        # ports:
+          # - 6379:6379
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.8'
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '8'
+
+      - run: make develop
+
+      - run: docker-compose
+
+      - run: |
+          psql -c 'create database test_freight;' -U postgres
+          if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+
+      - name: Lint
+        run: make lint
+
+      - name: Test
+        run: make test
+
+


### PR DESCRIPTION
`travis-ci.org` is shutting down at the end of the year. Here is a draft to use GitHub Actions instead. Another option is to migrate to `travis-ci.com`.