### PR TITLE
feat: Preselect default app

### DIFF
--- a/static/components/CreateDeploy.jsx
+++ b/static/components/CreateDeploy.jsx
@@ -13,7 +13,8 @@ class CreateDeploy extends React.Component {
   constructor(props) {
     super(props);
     const appList = props.appList;
-    const defaultApp = appList.length !== 0 ? appList[0] : null;
+    const getsentryApp = appList?.find(app => app.name === 'getsentry');
+    const defaultApp = getsentryApp ? getsentryApp : appList.length !== 0 ? appList[0] : null;
     const app = props.location.query?.app
       ? props.location.query.app
       : defaultApp


### PR DESCRIPTION
The `getsentry/production` looks like the most often deployed app in freight. 
I would like it to be therefore selected by default (every saved second counts, right?).

This is a naive wip solution, would like to move the hardcoded value to .env variable or something - this is OSS after all.