### PR TITLE
feat(config): Configurable Config

### DIFF
--- a/freight/providers/pipeline.py
+++ b/freight/providers/pipeline.py
@@ -72,10 +72,13 @@ class PipelineProvider(Provider):
         }
 
     def get_config(self, workspace, task) -> Dict[str, Any]:
-        options = [
-            Path(workspace.path) / ".freight.yml",
-            Path(workspace.path) / ".freight.yaml",
-        ]
+        try:
+            options = [Path(workspace.path) / task.provider_config["config_path"]]
+        except KeyError:
+            options = [
+                Path(workspace.path) / ".freight.yml",
+                Path(workspace.path) / ".freight.yaml",
+            ]
 
         extra_config: Dict[str, Any] = {}
         for option in options:

--- a/static/tests/__snapshots__/TimeSince.test.js.snap
+++ b/static/tests/__snapshots__/TimeSince.test.js.snap
@@ -4,6 +4,6 @@ exports[`TimeSince Snapshot 1`] = `
 <time
   dateTime="2016-12-21T23:36:07.071Z"
 >
-  5 years ago
+  6 years ago
 </time>
 `;


### PR DESCRIPTION
### Overview
- Freight currently looks for either `.freight.yml` or `.freight.yaml` to run per deploy
- I've introduced support for a `config_path` field in the provider config in which you can pass a file name to pick up as the freight config
- This will allow multiple freight configs per repo, each mapped to their own Freight application
- eg. Snuba can split its freight config into 2 different files containing different consumers in each, and a new freight app can be introduced to separately deploy those consumers