### PR TITLE
fix(config): add config_path to pipeline provider config keys, and raise ApiError if this happens again

### DIFF
--- a/freight/providers/pipeline.py
+++ b/freight/providers/pipeline.py
@@ -69,6 +69,7 @@ class PipelineProvider(Provider):
             "steps": {"required": False, "type": list},
             "kubernetes": {"required": False, "type": dict},
             "sentry": {"required": False, "type": dict},
+            "config_path": {"required": False, "type": str},
         }
 
     def get_config(self, workspace, task) -> Dict[str, Any]:

--- a/freight/providers/utils.py
+++ b/freight/providers/utils.py
@@ -1,5 +1,3 @@
-from itertools import chain
-
 from freight.exceptions import ApiError
 
 from . import manager
@@ -12,11 +10,16 @@ def parse_provider_config(type, config):
         raise ApiError(message=f"Invalid provider: {type}", name="invalid_provider")
 
     result = {}
-    all_options = chain(
-        list(instance.get_default_options().items()),
-        list(instance.get_options().items()),
-    )
-    for option, option_values in all_options:
+    all_options = {**instance.get_default_options(), **instance.get_options()}
+
+    for key in config:
+        if not all_options.get(key):
+            raise ApiError(
+                message=f"You specified config key {key}, but it isn't recognized for the provider {type}.",
+                name="invalid_provider",
+            )
+
+    for option, option_values in all_options.items():
         value = config.get(option)
         if value and option_values.get("type"):
             try:

--- a/freight/providers/utils.py
+++ b/freight/providers/utils.py
@@ -13,7 +13,7 @@ def parse_provider_config(type, config):
     all_options = {**instance.get_default_options(), **instance.get_options()}
 
     for key in config:
-        if not all_options.get(key):
+        if key not in all_options:
             raise ApiError(
                 message=f"You specified config key {key}, but it isn't recognized for the provider {type}.",
                 name="invalid_provider",

--- a/tests/providers/test_shell.py
+++ b/tests/providers/test_shell.py
@@ -72,12 +72,12 @@ class ParseProviderConfigTest(ShellProviderBase):
     def test_unused_key(self):
         with pytest.raises(ApiError) as e:
             parse_provider_config("shell", {"command": "/usr/bin/true", "foo": "bar"})
-        assert e.value.message == "You specified config key foo, but it isn't recognized for the provider shell."
+        assert str(e.value) == "You specified config key foo, but it isn't recognized for the provider shell."
 
     def test_requires_command(self):
         with pytest.raises(ApiError) as e:
             parse_provider_config("shell", {})
-        assert e.value.message == 'Missing required option "command" for provider: shell'
+        assert str(e.value) == 'Missing required option "command" for provider: shell'
 
     def test_valid_env(self):
         result = parse_provider_config(
@@ -88,4 +88,4 @@ class ParseProviderConfigTest(ShellProviderBase):
     def test_invalid_env(self):
         with pytest.raises(ApiError) as e:
             parse_provider_config("shell", {"command": "/usr/bin/true", "env": "FOO"})
-        assert e.value.message == 'Option "env" is not a valid type for provider: shell'
+        assert  str(e.value) == 'Option "env" is not a valid type for provider: shell'

--- a/tests/providers/test_shell.py
+++ b/tests/providers/test_shell.py
@@ -72,7 +72,10 @@ class ParseProviderConfigTest(ShellProviderBase):
     def test_unused_key(self):
         with pytest.raises(ApiError) as e:
             parse_provider_config("shell", {"command": "/usr/bin/true", "foo": "bar"})
-        assert str(e.value) == "You specified config key foo, but it isn't recognized for the provider shell."
+        assert (
+            str(e.value)
+            == "You specified config key foo, but it isn't recognized for the provider shell."
+        )
 
     def test_requires_command(self):
         with pytest.raises(ApiError) as e:
@@ -88,4 +91,4 @@ class ParseProviderConfigTest(ShellProviderBase):
     def test_invalid_env(self):
         with pytest.raises(ApiError) as e:
             parse_provider_config("shell", {"command": "/usr/bin/true", "env": "FOO"})
-        assert  str(e.value) == 'Option "env" is not a valid type for provider: shell'
+        assert str(e.value) == 'Option "env" is not a valid type for provider: shell'

--- a/tests/providers/test_shell.py
+++ b/tests/providers/test_shell.py
@@ -69,9 +69,15 @@ class ParseProviderConfigTest(ShellProviderBase):
         result = parse_provider_config("shell", {"command": "/usr/bin/true"})
         assert result["command"] == "/usr/bin/true"
 
+    def test_unused_key(self):
+        with pytest.raises(ApiError) as e:
+            parse_provider_config("shell", {"command": "/usr/bin/true", "foo": "bar"})
+        assert e.value.message == "You specified config key foo, but it isn't recognized for the provider shell."
+
     def test_requires_command(self):
-        with pytest.raises(ApiError):
+        with pytest.raises(ApiError) as e:
             parse_provider_config("shell", {})
+        assert e.value.message == 'Missing required option "command" for provider: shell'
 
     def test_valid_env(self):
         result = parse_provider_config(
@@ -80,5 +86,6 @@ class ParseProviderConfigTest(ShellProviderBase):
         assert result["env"] == {"FOO": "BAR"}
 
     def test_invalid_env(self):
-        with pytest.raises(ApiError):
+        with pytest.raises(ApiError) as e:
             parse_provider_config("shell", {"command": "/usr/bin/true", "env": "FOO"})
+        assert e.value.message == 'Option "env" is not a valid type for provider: shell'


### PR DESCRIPTION
f/u to https://github.com/getsentry/freight/pull/303. Freight was transparently deleting the config_path I was adding. Now it should raise an ApiError.