### PR TITLE
feat(remotes): Add support for 'VcsRemote's

### DIFF
--- a/freight/vcsremote/__init__.py
+++ b/freight/vcsremote/__init__.py
@@ -1,0 +1,8 @@
+from .manager import VcsRemoteManager
+from .github import GitHubVcsRemote
+
+manager = VcsRemoteManager()
+manager.add("github", GitHubVcsRemote)
+
+get = manager.get
+get_by_repo = manager.get_by_repo

--- a/freight/vcsremote/base.py
+++ b/freight/vcsremote/base.py
@@ -1,0 +1,22 @@
+class VcsRemote:
+    hostname: str
+    """
+    The hostname of the remote. Used by the VcsRemoteManager to map a VCS
+    remote URL to a VcsRemote.
+    """
+
+    def __init__(self, repo):
+        self.repo = repo
+
+    @property
+    def repo_url(self) -> str:
+        """
+        Get's the base URL for the remote repository
+        """
+        raise NotImplementedError
+
+    def get_commit_url(self, commit: str) -> str:
+        """
+        Get the URL for a particular commit on the remote
+        """
+        raise NotImplementedError

--- a/freight/vcsremote/dummy.py
+++ b/freight/vcsremote/dummy.py
@@ -1,0 +1,12 @@
+from .base import VcsRemote
+
+
+class DummyVcsRemote(VcsRemote):
+    hostname = "example.com"
+
+    @property
+    def repo_url(self) -> str:
+        return ""
+
+    def get_commit_url(self, sha: str) -> str:
+        return ""

--- a/freight/vcsremote/github.py
+++ b/freight/vcsremote/github.py
@@ -1,0 +1,24 @@
+__all__ = ["GitHubVcsRemote"]
+
+import re
+
+from .base import VcsRemote
+
+
+class GitHubVcsRemote(VcsRemote):
+    hostname = "github.com"
+
+    @property
+    def repo_url(self) -> str:
+        result = re.search(r"(?<=:)(?P<repo>[^\/]+\/[^.]+)", self.repo.url)
+
+        if result is None:
+            raise RuntimeError(
+                "GitHub repo URL does not match expected format giithub.com:owner/repo.git"
+            )
+
+        repo = result.group("repo")
+        return f"https://github.com/{repo}"
+
+    def get_commit_url(self, sha: str) -> str:
+        return f"{self.repo_url}/commit/{sha}"

--- a/freight/vcsremote/manager.py
+++ b/freight/vcsremote/manager.py
@@ -1,0 +1,23 @@
+__all__ = ["VcsRemoteManager"]
+
+
+from freight.vcsremote.base import VcsRemote
+from freight.vcsremote.dummy import DummyVcsRemote
+
+
+class VcsRemoteManager:
+    def __init__(self):
+        self.backends = {}
+
+    def add(self, name, cls):
+        self.backends[name] = cls
+
+    def get(self, name, **kwargs) -> VcsRemote:
+        return self.backends.get(name)(**kwargs)
+
+    def get_by_repo(self, repo, **kwargs) -> VcsRemote:
+        try:
+            backend = next(b for b in self.backends.values() if b.hostname in repo.url)
+        except StopIteration:
+            return DummyVcsRemote(repo)
+        return backend(repo, **kwargs)


### PR DESCRIPTION
This provides a way to have some context into the deploys VCS remotes.

This adds GitHub as a VCS remote, since that's primarily what Sentry
uses.