### PR TITLE
fix: Rename 'stats' endpoint to stop adblock from blocking it

### DIFF
--- a/freight/config.py
+++ b/freight/config.py
@@ -169,7 +169,7 @@ def configure_api(app):
     api.add_resource(AppIndexApiView, "/apps/")
     api.add_resource(AppDetailsApiView, "/apps/<app>/")
     api.add_resource(ConfigApiView, "/config/")
-    api.add_resource(StatsApiView, "/stats/")
+    api.add_resource(StatsApiView, "/deploy-stats/")
     api.add_resource(DeployIndexApiView, "/tasks/", endpoint="deploy-index-deprecated")
     api.add_resource(DeployIndexApiView, "/deploys/")
 

--- a/static/components/DeployChart.jsx
+++ b/static/components/DeployChart.jsx
@@ -34,7 +34,7 @@ const DeployChart = createReactClass({
 
   getPollingUrl() {
     const {app} = this.props;
-    return `/stats/${app ? `?app=${app}` : ''}`;
+    return `/deploy-stats/${app ? `?app=${app}` : ''}`;
   },
 
   pollingReceiveData(data) {

--- a/tests/api/test_stats.py
+++ b/tests/api/test_stats.py
@@ -5,7 +5,7 @@ from freight.testutils import TestCase
 
 
 class StatsBase(TestCase):
-    path = "/api/0/stats/"
+    path = "/api/0/deploy-stats/"
 
     def setUp(self):
         self.user = self.create_user()


### PR DESCRIPTION
typically looks like this with adblock on

![image](https://user-images.githubusercontent.com/1421724/181112491-c729b09e-5055-4310-8cd0-20ee1366a28e.png)

renamed it looks like this

![image](https://user-images.githubusercontent.com/1421724/181112522-cd9b88aa-c101-48d2-9ed8-cf640e3d170d.png)
