### PR TITLE
ref(js): Use custom tooltip for charts

### DIFF
--- a/static/components/BarChart.jsx
+++ b/static/components/BarChart.jsx
@@ -2,8 +2,6 @@ import React from 'react';
 import {addMinutes, addSeconds, format} from 'date-fns';
 import PropTypes from 'prop-types';
 
-import TooltipTrigger from './TooltipTrigger';
-
 class BarChart extends React.Component {
   static propTypes = {
     height: PropTypes.string,
@@ -12,11 +10,9 @@ class BarChart extends React.Component {
       PropTypes.shape({
         x: PropTypes.number.isRequired,
         y: PropTypes.number.isRequired,
-        label: PropTypes.string,
       })
     ),
     placement: PropTypes.string,
-    label: PropTypes.string,
   };
 
   static defaultProps = {
@@ -97,23 +93,19 @@ class BarChart extends React.Component {
       const pct = this.floatFormat((point.y / maxval) * 99, 2) + '%';
       const timeLabel = timeLabelFunc(point);
 
-      let title = (
+      const tooltipText = (
         <div style={{minWidth: 100}}>
           {point.y} {this.props.label}
           <br />
           {timeLabel}
         </div>
       );
-      if (point.label) {
-        title += <div>({point.label})</div>;
-      }
 
       return (
-        <TooltipTrigger placement={this.props.placement} key={point.x} title={title}>
-          <a style={{width: pointWidth}}>
-            <span style={{height: pct}}>{point.y}</span>
-          </a>
-        </TooltipTrigger>
+        <div key={point.x} className="barchart-bar" style={{width: pointWidth}}>
+          <span style={{height: pct}}>{point.y}</span>
+          <div className="barchart-tooltip">{tooltipText}</div>
+        </div>
       );
     });
 

--- a/static/less/base.less
+++ b/static/less/base.less
@@ -445,15 +445,38 @@ figure.barchart {
   > .min-y {
     bottom: 3px;
   }
-  > a {
+  > .barchart-bar {
     position: relative;
     float: left;
     height: 100px;
     display: block;
+
+    > .barchart-tooltip {
+      visibility: hidden;
+      opacity: 0;
+      transition: opacity 300ms;
+      position: relative;
+      width: max-content;
+      bottom: -110px;
+      margin-left: 50%;
+      transform: translateX(-50%);
+      padding: 4px 6px;
+      border-radius: 3px;
+      background: #111;
+      text-align: center;
+      font-size: 12px;
+      color: #fff;
+      text-decoration: none;
+    }
+
     &:hover {
       > span {
         background: #fff;
         border-color: #fff;
+      }
+      > .barchart-tooltip {
+        opacity: 1;
+        visibility: visible;
       }
     }
     > span {


### PR DESCRIPTION
So we can kill off the jquery tooltip

looks like this
![image](https://user-images.githubusercontent.com/1421724/181119671-c06c5b1b-f6f5-45b9-a5b4-a25714938b6a.png)
