### PR TITLE
feat: adapt to getsentry/getsentry#7994

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,14 +22,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         openssh-client \
     && rm -rf /var/lib/apt/lists/*
 
-# add our user and group first to make sure their IDs get assigned consistently
-RUN groupadd -r freight && useradd -r -m -g freight freight
-
 # This is the build user on cheffed and salted host machines
-# that would run the Freight container. Directories that we volume
-# mount when running Freight are owned by 9010:9010 (build).
-# The Freight container is run with --user=9010:9010, but it needs to exist
-# in here for that to work.
+# that the Freight container should be run with.
+# Directories that we volume mount when running Freight are owned by 9010:9010 (build).
 RUN groupadd -g 9010 build && useradd -r -g 9010 -u 9010 build
 
 # grab gosu for easy step-down from root

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # add our user and group first to make sure their IDs get assigned consistently
 RUN groupadd -r freight && useradd -r -m -g freight freight
 
+# This is the build user on cheffed and salted host machines
+# that would run the Freight container. Directories that we volume
+# mount when running Freight are owned by 9010:9010.
+# The Freight container is run with --user=9010:9010, but it needs to exist
+# in here for that to work.
+RUN groupadd -g 9010 && useradd -r -g 9010 -u 9010
+
 # grab gosu for easy step-down from root
 RUN set -x \
     && GOSU_VERSION=1.11 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,9 +21,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         git \
     && rm -rf /var/lib/apt/lists/*
 
-# This is the build user on cheffed and salted host machines
-# that the Freight container should be run with.
+# This is the build (uid 9010) user on cheffed and salted host machines.
 # Directories that we volume mount when running Freight are owned by 9010:9010 (build).
+# In the docker entrypoint we have gosu stepping down to build, so just make sure
+# it's uid 9010.
 RUN groupadd -g 9010 build && useradd -r -g 9010 -u 9010 build
 
 # grab gosu for easy step-down from root

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # it's uid 9010.
 RUN groupadd -g 9010 build && useradd -r -g 9010 -u 9010 build
 
+# During runtime, Freight runs as the build user (stepped down to by gosu),
+# and its docker client needs to be able to read this file.
+COPY --chown=build:build ./docker/config.json /home/build/.docker/config.json
+
 # grab gosu for easy step-down from root
 RUN set -x \
     && GOSU_VERSION=1.11 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,10 +27,10 @@ RUN groupadd -r freight && useradd -r -m -g freight freight
 
 # This is the build user on cheffed and salted host machines
 # that would run the Freight container. Directories that we volume
-# mount when running Freight are owned by 9010:9010.
+# mount when running Freight are owned by 9010:9010 (build).
 # The Freight container is run with --user=9010:9010, but it needs to exist
 # in here for that to work.
-RUN groupadd -g 9010 && useradd -r -g 9010 -u 9010
+RUN groupadd -g 9010 build && useradd -r -g 9010 -u 9010 build
 
 # grab gosu for easy step-down from root
 RUN set -x \

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Directories that we volume mount when running Freight are owned by 9010:9010 (build).
 RUN groupadd -g 9010 build && useradd -r -g 9010 -u 9010 build
 
+# grab gosu for easy step-down from root
+RUN set -x \
+    && GOSU_VERSION=1.11 \
+    && GOSU_SHA256=0b843df6d86e270c5b0f5cbd3c326a04e18f4b7f9b8457fa497b0454c4b138d7 \
+    && curl -sL -o /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-$(dpkg --print-architecture)" \
+    && echo "${GOSU_SHA256} /usr/local/bin/gosu" | sha256sum --check --status \
+    && chmod +x /usr/local/bin/gosu \
+    && gosu nobody true
+
 # grab tini for signal processing and zombie killing
 RUN set -x \
     && TINI_VERSION=0.18.0 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,6 @@ ENV PIP_NO_CACHE_DIR=off \
 RUN apt-get update && apt-get install -y --no-install-recommends \
         curl \
         git \
-        openssh-client \
     && rm -rf /var/lib/apt/lists/*
 
 # This is the build user on cheffed and salted host machines

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,15 +27,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Directories that we volume mount when running Freight are owned by 9010:9010 (build).
 RUN groupadd -g 9010 build && useradd -r -g 9010 -u 9010 build
 
-# grab gosu for easy step-down from root
-RUN set -x \
-    && GOSU_VERSION=1.11 \
-    && GOSU_SHA256=0b843df6d86e270c5b0f5cbd3c326a04e18f4b7f9b8457fa497b0454c4b138d7 \
-    && curl -sL -o /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-$(dpkg --print-architecture)" \
-    && echo "${GOSU_SHA256} /usr/local/bin/gosu" | sha256sum --check --status \
-    && chmod +x /usr/local/bin/gosu \
-    && gosu nobody true
-
 # grab tini for signal processing and zombie killing
 RUN set -x \
     && TINI_VERSION=0.18.0 \

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -14,23 +14,13 @@ case "$1" in
     ;;
 esac
 
-export GOOGLE_APPLICATION_CREDENTIALS=/home/freight/google-credentials.json
-
-# copy the file to someplace we can set permissions
-# REMINDER: this file MUST persist or periodic auth refresh WILL FAIL and revert to any auth it can find
-#    (e.g. garbage's instance credentials)
-cp /etc/freight/google-credentials.json ${GOOGLE_APPLICATION_CREDENTIALS}
-chown freight ${GOOGLE_APPLICATION_CREDENTIALS}
-
-email=$(cat ${GOOGLE_APPLICATION_CREDENTIALS} | grep client_email | sed -e "s/.*: \"//" | sed -e "s/\",//")
-
-gosu freight bash -c "gcloud auth activate-service-account ${email} --key-file=${GOOGLE_APPLICATION_CREDENTIALS} -q" # this sets up region/zone based on key file
-
+email=$(grep client_email /etc/freight/google-credentials.json | sed -e "s/.*: \"//" | sed -e "s/\",//")
+gcloud auth activate-service-account "$email" --key-file=/etc/freight/google-credentials.json -q
 unset email
 
-mkdir -p /home/freight/.docker/
-chown freight:freight /home/freight/.docker/
-cp /etc/freight/config.json /home/freight/.docker/config.json
-chown freight:freight /home/freight/.docker/config.json
+mkdir -p /home/build/.docker/
+chown build:build /home/build/.docker/
+cp /etc/freight/config.json /home/build/.docker/config.json
+chown build:build /home/build/.docker/config.json
 
 exec tini "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -18,11 +18,6 @@ email=$(grep client_email /etc/freight/google-credentials.json | sed -e "s/.*: \
 gcloud auth activate-service-account "$email" --key-file=/etc/freight/google-credentials.json -q
 unset email
 
-mkdir -p /home/build/.docker/
-chown build:build /home/build/.docker/
-cp /etc/freight/config.json /home/build/.docker/config.json
-chown build:build /home/build/.docker/config.json
-
 # TODO: try to chown this on the host.
 chown -R build:build "$WORKSPACE_ROOT"
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -2,12 +2,10 @@
 
 set -e
 
-# Unfortunately we can't remove gosu, we need to start the container
-# as root to at least chown WORKSPACE_ROOT since on garbage, that is
-# owned by td-agent:root.
-# TODO(newfreight): everything that Freight volume mounts should
-# be owned by build user (uid 9010). Then we can remove gosu,
-# and straight up run as build.
+if [[ "$(id -u)" != 9010 ]] || [[ "$(id -un)" != build ]]; then
+    echo "Freight needs to be run as user build with uid 9010."
+    exit 1
+fi
 
 # Perform an upgrade before booting up web/worker processes.
 case "$1" in
@@ -24,9 +22,10 @@ fi
 # If so, we'll want to drop to running it as the build user (uid 9010).
 if [ -f "/usr/src/app/bin/$1" ]; then
     set -- tini -- "$@"
-    if [ "$(id -u)" = '0' ]; then
-        mkdir -p "$WORKSPACE_ROOT"
-        chown -R build "$WORKSPACE_ROOT"
+    mkdir -p "$WORKSPACE_ROOT"
+    # ugh we actually need this,
+    # what's mounted to WORKSPACE_ROOT is td-agent:root on garbage. lol.
+    chown -R build "$WORKSPACE_ROOT"
         set -- gosu build "$@"
     fi
 fi

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -2,10 +2,10 @@
 
 set -e
 
-# Perform an upgrade before booting up web/worker processes
+# Perform an upgrade before booting up web/worker processes.
 case "$1" in
     web|worker)
-        gosu freight upgrade
+        gosu build upgrade
     ;;
 esac
 
@@ -13,13 +13,14 @@ if [ -f /etc/freight/auth-helpers.sh ]; then
     . /etc/freight/auth-helpers.sh
 fi
 
-# Check if we're trying to execute a freight bin
+# Check if we're trying to execute a freight bin as root.
+# If so, we'll want to drop to running it as the build user (uid 9010).
 if [ -f "/usr/src/app/bin/$1" ]; then
     set -- tini -- "$@"
     if [ "$(id -u)" = '0' ]; then
         mkdir -p "$WORKSPACE_ROOT"
-        chown -R freight "$WORKSPACE_ROOT"
-        set -- gosu freight "$@"
+        chown -R build "$WORKSPACE_ROOT"
+        set -- gosu build "$@"
     fi
 fi
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -9,14 +9,6 @@ case "$1" in
     ;;
 esac
 
-if [ "$DOCKER_CONFIG" ]; then
-    gosu freight bash -c 'mkdir -p ~/.docker'
-    gosu freight bash -c 'echo $DOCKER_CONFIG > ~/.docker/config.json'
-    gosu freight bash -c 'chmod 400 ~/.docker/config.json'
-    # Make sure we don't pass this along since it contains sensitive info
-    unset DOCKER_CONFIG
-fi
-
 if [ -f /etc/freight/auth-helpers.sh ]; then
     . /etc/freight/auth-helpers.sh
 fi

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -10,7 +10,7 @@ fi
 # Perform an upgrade before booting up web/worker processes.
 case "$1" in
     web|worker)
-        gosu build upgrade
+        upgrade
     ;;
 esac
 
@@ -18,16 +18,4 @@ if [ -f /etc/freight/auth-helpers.sh ]; then
     . /etc/freight/auth-helpers.sh
 fi
 
-# Check if we're trying to execute a freight bin as root.
-# If so, we'll want to drop to running it as the build user (uid 9010).
-if [ -f "/usr/src/app/bin/$1" ]; then
-    set -- tini -- "$@"
-    mkdir -p "$WORKSPACE_ROOT"
-    # ugh we actually need this,
-    # what's mounted to WORKSPACE_ROOT is td-agent:root on garbage. lol.
-    chown -R build "$WORKSPACE_ROOT"
-        set -- gosu build "$@"
-    fi
-fi
-
-exec "$@"
+exec tini "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -2,6 +2,11 @@
 
 set -e
 
+if [[ "$(id -u)" != 0 ]]; then
+    echo "Freight needs to be run as root user (we step down to build user before leaving the entrypoint)"
+    exit 1
+fi
+
 # Perform an upgrade before booting up web/worker processes.
 case "$1" in
     web|worker)
@@ -18,6 +23,7 @@ chown build:build /home/build/.docker/
 cp /etc/freight/config.json /home/build/.docker/config.json
 chown build:build /home/build/.docker/config.json
 
+# TODO: try to chown this on the host.
 chown -R build:build "$WORKSPACE_ROOT"
 
 exec tini gosu build "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -2,15 +2,10 @@
 
 set -e
 
-if [[ "$(id -u)" != 9010 ]] || [[ "$(id -un)" != build ]]; then
-    echo "Freight needs to be run as user build with uid 9010."
-    exit 1
-fi
-
 # Perform an upgrade before booting up web/worker processes.
 case "$1" in
     web|worker)
-        upgrade
+        gosu build upgrade
     ;;
 esac
 
@@ -23,4 +18,6 @@ chown build:build /home/build/.docker/
 cp /etc/freight/config.json /home/build/.docker/config.json
 chown build:build /home/build/.docker/config.json
 
-exec tini "$@"
+chown -R build:build "$WORKSPACE_ROOT"
+
+exec tini gosu build "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -2,6 +2,11 @@
 
 set -e
 
+if [[ "$(id -u)" != 9010 ]] || [[ "$(id -un)" != build ]]; then
+    echo "Freight needs to be run as user build with uid 9010."
+    exit 1
+fi
+
 # Perform an upgrade before booting up web/worker processes.
 case "$1" in
     web|worker)
@@ -17,9 +22,10 @@ fi
 # If so, we'll want to drop to running it as the build user (uid 9010).
 if [ -f "/usr/src/app/bin/$1" ]; then
     set -- tini -- "$@"
-    if [ "$(id -u)" = '0' ]; then
-        mkdir -p "$WORKSPACE_ROOT"
-        chown -R build "$WORKSPACE_ROOT"
+    mkdir -p "$WORKSPACE_ROOT"
+    # ugh we actually need this,
+    # what's mounted to WORKSPACE_ROOT is td-agent:root on garbage. lol.
+    chown -R build "$WORKSPACE_ROOT"
         set -- gosu build "$@"
     fi
 fi

--- a/docker/config.json
+++ b/docker/config.json
@@ -1,0 +1,10 @@
+{
+  "auths": {},
+  "credHelpers": {
+    "gcr.io": "gcloud",
+    "us.gcr.io": "gcloud",
+    "eu.gcr.io": "gcloud",
+    "asia.gcr.io": "gcloud",
+    "staging-k8s.gcr.io": "gcloud"
+  }
+}


### PR DESCRIPTION
This is needed for https://github.com/getsentry/getsentry/pull/7994, which removes fabric/remote execution.

It used to be that the Freight container would run on garbage and literally ssh into.... garbage to do stuff as the "build" user. Lol.

Now, since that's trying to run directly inside the Freight container, `/srv/www/getsentry.com` on garbage (build:build uid 9010) needs to be volume mounted. 