### PR TITLE
feat(ui): Represent remote-changes in create deploy

### DIFF
--- a/static/hooks/useLastDeploay.jsx
+++ b/static/hooks/useLastDeploay.jsx
@@ -1,0 +1,29 @@
+import {useCallback, useEffect, useState} from 'react';
+
+import api from 'app/api';
+
+/**
+ * Fetches the most recent deploy details for an app/env
+ */
+function useLastDeploy({app, env}) {
+  const [lastDeploy, setLastDeploy] = useState(undefined);
+
+  const fetchLastDeploy = useCallback(async () => {
+    setLastDeploy(undefined);
+
+    const deploysResp = await api.request('/deploys/', {
+      query: {app, env, status: 'finished'},
+    });
+
+    if (deploysResp.ok) {
+      const deploys = await deploysResp.json();
+      setLastDeploy(deploys[0] ?? null);
+    }
+  }, [app, env]);
+
+  useEffect(() => void fetchLastDeploy(), [fetchLastDeploy]);
+
+  return lastDeploy;
+}
+
+export default useLastDeploy;

--- a/static/hooks/useRemoteChanges.jsx
+++ b/static/hooks/useRemoteChanges.jsx
@@ -1,0 +1,35 @@
+import {useCallback, useEffect, useState} from 'react';
+
+import api from 'app/api';
+
+/**
+ * Fetches the expected changes for an app, given the start and end ref.
+ */
+function useRemoteChanges({app, startRef, endRef}) {
+  const [changes, setChanges] = useState(undefined);
+
+  const fetchRemoteChanges = useCallback(async () => {
+    setChanges(undefined);
+
+    if (startRef === undefined || endRef === undefined) {
+      setChanges([]);
+      return;
+    }
+
+    const changesResp = await api.request(`/remote-changes/${app}/`, {
+      query: {startRef, endRef},
+    });
+
+    if (changesResp.ok) {
+      setChanges(await changesResp.json());
+    } else {
+      setChanges(null);
+    }
+  }, [app, endRef, startRef]);
+
+  useEffect(() => void fetchRemoteChanges(), [fetchRemoteChanges]);
+
+  return changes;
+}
+
+export default useRemoteChanges;

--- a/static/less/base.less
+++ b/static/less/base.less
@@ -270,6 +270,82 @@ header {
     }
   }
 }
+
+.remote-changes {
+  list-style: none;
+  padding-left: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+
+  li {
+    position: relative;
+  }
+
+  li::before {
+    content: '';
+    position: absolute;
+    left: -19px;
+    top: 5px;
+    width: 11px;
+    height: 11px;
+    border: 2px solid lighten(@lessDark, 40%);
+    border-radius: 50%;
+    z-index: 2;
+  }
+
+  li:not(:last-of-type)::after {
+    content: '';
+    position: absolute;
+    top: 14px;
+    left: -14px;
+    width: 1px;
+    height: calc(100% + 4px);
+    background: lighten(@lessDark, 60%);
+  }
+
+  .change-title {
+    font-weight: 600;
+    line-height: 1.5;
+    margin-bottom: 4px;
+  }
+
+  time {
+    color: lighten(@lessDark, 40%);
+  }
+
+  .change-tags {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    height: 25px;
+
+    > * {
+      height: 24px;
+      display: flex;
+      align-items: center;
+      font-size: 13px;
+      gap: 6px;
+      font-weight: 500;
+    }
+
+    .change-author img {
+      width: 16px;
+      height: 16px;
+      border-radius: 50%;
+    }
+
+    .change-label {
+      font-size: 12px;
+      color: @light;
+      padding: 0 8px;
+      border-radius: 10px;
+      height: 20px;
+      line-height: 100%;
+    }
+  }
+}
+
 @-webkit-keyframes animate-stripes {
   0% {
     background-position: 0 0;
@@ -278,6 +354,7 @@ header {
     background-position: 60px 0;
   }
 }
+
 .deploy-details {
   padding-top: 40px;
   padding-bottom: 30px;

--- a/static/tests/__snapshots__/CreateDeploy.test.js.snap
+++ b/static/tests/__snapshots__/CreateDeploy.test.js.snap
@@ -92,19 +92,30 @@ exports[`CreateDeploy Snapshot should render 1`] = `
             value="master"
           />
         </div>
-        <ExpectedChanges
-          app="freight"
-          env="production"
+        <div
+          className="form-group"
         >
-          <div>
-            <label>
-              Previous Deploy
-            </label>
+          <label>
+            Last Deploy
+          </label>
+          <p>
+            Loading previous deploy details
+          </p>
+        </div>
+        <div
+          className="form-group"
+        >
+          <label>
+            Changes Since
+          </label>
+          <ExpectedChanges
+            changes={Array []}
+          >
             <p>
-              Loading previous deploy info
+              Nothing to deploy!
             </p>
-          </div>
-        </ExpectedChanges>
+          </ExpectedChanges>
+        </div>
         <div
           className="submit-group"
         >

--- a/static/views/CreateDeploy.jsx
+++ b/static/views/CreateDeploy.jsx
@@ -3,6 +3,9 @@ import {browserHistory} from 'react-router';
 
 import api from 'app/api';
 import ExpectedChanges from 'app/components/ExpectedChanges';
+import TaskSummary from 'app/components/TaskSummary';
+import useLastDeploy from 'app/hooks/useLastDeploay';
+import useRemoteChanges from 'app/hooks/useRemoteChanges';
 
 function gotoDeploy(deploy) {
   const {app, environment, number} = deploy;
@@ -41,6 +44,9 @@ function CreateDeploy({location, appList = []}) {
 
   const [submitError, setSubmitError] = React.useState(false);
   const [submitInProgress, setSubmitInProgress] = React.useState(false);
+
+  const lastDeploy = useLastDeploy({app, env});
+  const changes = useRemoteChanges({app, startRef: ref, endRef: lastDeploy?.sha});
 
   const startDeploy = React.useCallback(async () => {
     const deployResp = await api.request('/deploys/', {
@@ -122,7 +128,24 @@ function CreateDeploy({location, appList = []}) {
               value={ref}
             />
           </div>
-          <ExpectedChanges app={app} env={env} />
+
+          <div className="form-group">
+            <label>Last Deploy</label>
+            {lastDeploy === undefined ? (
+              <p>Loading previous deploy details</p>
+            ) : lastDeploy === null ? (
+              <p>
+                This will be the first deploy of {app}/{env}
+              </p>
+            ) : (
+              <TaskSummary task={lastDeploy} />
+            )}
+          </div>
+
+          <div className="form-group">
+            <label>Changes Since</label>
+            <ExpectedChanges changes={changes} />
+          </div>
 
           <div className="submit-group">
             <button type="submit" className="btn btn-primary" disabled={submitInProgress}>


### PR DESCRIPTION
Adds UI elements that use the remote-changes API

Looks like this

![image](https://user-images.githubusercontent.com/1421724/183142684-29091967-d5c3-44e3-9d07-4ddcf79bcf5d.png)

In the future I'd like to have a feature that differentiates what will
be deployed based on the Scope tags. Though we'll need a bit more
configuration for the app to do that.