### PR TITLE
ref(git): Make the get_sha_range exclusive

### DIFF
--- a/freight/vcs/git.py
+++ b/freight/vcs/git.py
@@ -63,13 +63,7 @@ class GitVcs(Vcs):
         return self.run(["rev-parse", ref])
 
     def get_sha_range(self, ref1, ref2):
-        # --boundary makes the list inclusive. Though we need to strip off the
-        # ending `-` that indicates the boundary commit.
-        shas = (
-            self.run(["rev-list", "--ancestry-path", "--boundary", f"{ref2}..{ref1}"])
-            .replace("-", "")
-            .split("\n")
-        )
+        shas = self.run(["rev-list", "--ancestry-path", f"{ref2}..{ref1}"]).split("\n")
 
         if shas[0] == "":
             return []

--- a/tests/vcs/test_git.py
+++ b/tests/vcs/test_git.py
@@ -105,7 +105,7 @@ class GitVcsTest(TestCase):
         vcs.update()
 
         shas = vcs.get_sha_range("master", "master^")
-        assert len(shas) == 2
+        assert len(shas) == 1
 
     def test_empty_get_sha_range(self):
         vcs = self.get_vcs()


### PR DESCRIPTION
This actually makes more sense for the use case of listing changes to be
deployed, since we don't want to actually include the most recently
deployed commit.