### PR TITLE
ref(remotevcs): Add `get_sha_range` using github compare API

### DIFF
--- a/freight/vcsremote/base.py
+++ b/freight/vcsremote/base.py
@@ -29,3 +29,9 @@ class VcsRemote:
         Retrieves detailed information from the remote for a list of commits.
         """
         raise NotImplementedError
+
+    def get_sha_range(self, ref1, ref2):
+        """
+        Given two refs, returna list of SHAs between and including the refs.
+        """
+        raise NotImplementedError

--- a/freight/vcsremote/github.py
+++ b/freight/vcsremote/github.py
@@ -198,3 +198,22 @@ class GitHubVcsRemote(VcsRemote):
         # TODO Ensure order matches the shas list
 
         return list(commits_dict.values())
+
+    def get_sha_range(self, ref1, ref2):
+        token = current_app.config["GITHUB_TOKEN"]
+        headers = {
+            "Authorization": f"token {token}",
+        }
+
+        repo_owner, repo_name = self.repo_parts
+
+        # XXX(epurkhiser): There is no graphql equivalent of the compare API.
+        # Not a huge problem though, we can just use the REST API.
+        compare_resp = http.get(
+            f"https://api.github.com/repos/{repo_owner}/{repo_name}/compare/{ref2}...{ref1}",
+            headers=headers,
+        )
+
+        return list(
+            reversed([commit["sha"] for commit in compare_resp.json()["commits"]])
+        )


### PR DESCRIPTION
This avoids having to update the local clone of the repo when using the
remote-changes API, which was already pretty flakey due to needing to
lock while using it.