### PR TITLE
ref(js): Add useApi hook to cancel requests on unmount

### DIFF
--- a/static/components/Layout.jsx
+++ b/static/components/Layout.jsx
@@ -3,10 +3,12 @@ import {Link} from 'react-router';
 // eslint-disable-next-line no-restricted-imports
 import {init} from '@sentry/browser';
 
-import api from 'app/api';
 import LoadingIndicator from 'app/components/LoadingIndicator';
+import useApi from 'app/hooks/useApi';
 
 function Layout({params, children}) {
+  const api = useApi();
+
   const {app} = params;
 
   const [appList, setAppList] = React.useState([]);
@@ -54,7 +56,7 @@ function Layout({params, children}) {
     }
 
     setLoading(false);
-  }, []);
+  }, [api]);
 
   React.useEffect(() => void fetchData(), [fetchData]);
 

--- a/static/hooks/useApi.jsx
+++ b/static/hooks/useApi.jsx
@@ -1,0 +1,31 @@
+import {useCallback, useEffect, useRef} from 'react';
+
+import Client from 'app/api';
+
+/**
+ * Returns an API client that will have it's requests canceled when the owning
+ * React component is unmounted (may be disabled via options).
+ */
+function useApi({persistInFlight} = {}) {
+  const localApi = useRef();
+
+  if (localApi.current === undefined) {
+    localApi.current = new Client();
+  }
+
+  // Use the provided client if available
+  const api = localApi.current;
+
+  // Clear API calls on unmount (if persistInFlight is disabled
+  const clearOnUnmount = useCallback(() => {
+    if (!persistInFlight) {
+      api.clear();
+    }
+  }, [api, persistInFlight]);
+
+  useEffect(() => clearOnUnmount, [clearOnUnmount]);
+
+  return api;
+}
+
+export default useApi;

--- a/static/hooks/useLastDeploay.jsx
+++ b/static/hooks/useLastDeploay.jsx
@@ -1,15 +1,18 @@
 import {useCallback, useEffect, useState} from 'react';
 
-import api from 'app/api';
+import useApi from 'app/hooks/useApi';
 
 /**
  * Fetches the most recent deploy details for an app/env
  */
 function useLastDeploy({app, env}) {
+  const api = useApi();
+
   const [lastDeploy, setLastDeploy] = useState(undefined);
 
   const fetchLastDeploy = useCallback(async () => {
     setLastDeploy(undefined);
+    api.clear();
 
     const deploysResp = await api.request('/deploys/', {
       query: {app, env, status: 'finished'},
@@ -19,7 +22,7 @@ function useLastDeploy({app, env}) {
       const deploys = await deploysResp.json();
       setLastDeploy(deploys[0] ?? null);
     }
-  }, [app, env]);
+  }, [api, app, env]);
 
   useEffect(() => void fetchLastDeploy(), [fetchLastDeploy]);
 

--- a/static/hooks/usePolling.jsx
+++ b/static/hooks/usePolling.jsx
@@ -1,6 +1,6 @@
 import {useCallback, useEffect, useRef} from 'react';
 
-import api from 'app/api';
+import useApi from 'app/hooks/useApi';
 
 /**
  * How long between polls
@@ -13,6 +13,8 @@ const DEFAULT_DELAY = 3000;
 const BACKOFF_DELAY = 10000;
 
 function usePolling({url, handleRecieveData, pollingActive = true}) {
+  const api = useApi();
+
   /**
    * Returns true if request was successful, false otherwise.
    */
@@ -25,7 +27,7 @@ function usePolling({url, handleRecieveData, pollingActive = true}) {
     }
 
     return pollResp.ok;
-  }, [url, handleRecieveData]);
+  }, [api, url, handleRecieveData]);
 
   const pollTimeoutRef = useRef(undefined);
 

--- a/static/hooks/useRemoteChanges.jsx
+++ b/static/hooks/useRemoteChanges.jsx
@@ -1,15 +1,17 @@
 import {useCallback, useEffect, useState} from 'react';
 
-import api from 'app/api';
+import useApi from 'app/hooks/useApi';
 
 /**
  * Fetches the expected changes for an app, given the start and end ref.
  */
 function useRemoteChanges({app, startRef, endRef}) {
+  const api = useApi();
   const [changes, setChanges] = useState(undefined);
 
   const fetchRemoteChanges = useCallback(async () => {
     setChanges(undefined);
+    api.clear();
 
     if (!startRef || !endRef) {
       setChanges([]);
@@ -25,7 +27,7 @@ function useRemoteChanges({app, startRef, endRef}) {
     } else {
       setChanges(null);
     }
-  }, [app, endRef, startRef]);
+  }, [api, app, endRef, startRef]);
 
   useEffect(() => void fetchRemoteChanges(), [fetchRemoteChanges]);
 

--- a/static/views/AppDetails.jsx
+++ b/static/views/AppDetails.jsx
@@ -1,12 +1,13 @@
 import * as React from 'react';
 
-import api from 'app/api';
 import DeployChart from 'app/components/DeployChart';
 import LoadingIndicator from 'app/components/LoadingIndicator';
 import TaskSummary from 'app/components/TaskSummary';
+import useApi from 'app/hooks/useApi';
 import usePolling from 'app/hooks/usePolling';
 
 function AppDetails({params}) {
+  const api = useApi();
   const [error, setError] = React.useState(false);
 
   const [app, setApp] = React.useState(null);
@@ -24,7 +25,7 @@ function AppDetails({params}) {
           : 'Error fetching data';
       setError(errorMessage);
     }
-  }, [params.app]);
+  }, [api, params.app]);
 
   // Load app
   React.useEffect(() => void loadApp(), [loadApp]);

--- a/static/views/CreateDeploy.jsx
+++ b/static/views/CreateDeploy.jsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import {browserHistory} from 'react-router';
 
-import api from 'app/api';
 import ExpectedChanges from 'app/components/ExpectedChanges';
 import TaskSummary from 'app/components/TaskSummary';
+import useApi from 'app/hooks/useApi';
 import useLastDeploy from 'app/hooks/useLastDeploay';
 import useRemoteChanges from 'app/hooks/useRemoteChanges';
 
@@ -13,6 +13,7 @@ function gotoDeploy(deploy) {
 }
 
 function CreateDeploy({location, appList = []}) {
+  const api = useApi();
   const firstApp = appList.length !== 0 ? appList[0] : null;
 
   const defaultApp = location.query?.app
@@ -66,7 +67,7 @@ function CreateDeploy({location, appList = []}) {
       setSubmitError(result.error);
       setSubmitInProgress(false);
     }
-  }, [app, env, ref]);
+  }, [api, app, env, ref]);
 
   /**
    * Handles creating a deploy

--- a/static/views/TaskDetails.jsx
+++ b/static/views/TaskDetails.jsx
@@ -6,7 +6,7 @@ import {format} from 'date-fns';
 import linkifyUrls from 'linkify-urls';
 import PropTypes from 'prop-types';
 
-import api from 'app/api';
+import Client from 'app/api';
 import FaviconStatus from 'app/components/FaviconStatus';
 import LoadingIndicator from 'app/components/LoadingIndicator';
 import TaskSummary from 'app/components/TaskSummary';
@@ -20,6 +20,11 @@ function Progress({value}) {
 Progress.propTypes = {
   value: PropTypes.number.isRequired,
 };
+
+// XXX(epurkhiser): Until this component is functional, we can't use the useApi
+// hook that will smartly cancel API requets, so we'll instantiate a module
+// local api client for now.
+const api = new Client();
 
 const TaskDetails = createReactClass({
   displayName: 'TaskDetails',


### PR DESCRIPTION
Title says it all. Right now API requests will fire after components
unmount and attempt to update state