### PR TITLE
ref(ui): Fix ExpectedChanges message PR title cleanup

### DIFF
--- a/static/components/ExpectedChanges.jsx
+++ b/static/components/ExpectedChanges.jsx
@@ -22,7 +22,7 @@ function ExpectedChanges({changes}) {
     const resolvedCommit = commit.externalCommit ?? commit;
 
     const title = resolvedCommit?.messageHeadline ?? '';
-    const titleWithoutPr = title.replace(/ \(#[0-9]+\)?$/g, '');
+    const titleWithoutPr = title.replace(/ \(#[0-9]+(\u2026|\))$/g, '');
 
     const pr =
       resolvedCommit.associatedPullRequests.nodes.length > 0


### PR DESCRIPTION
We remove the `(#xxx)` string from the end of commit messages, since we'll add our own. Sometimes these are truncated like `(#12...`. This updates the regex to better handle that