### PR TITLE
fix(ui): Correct bad key in ExpectedChanges

### DIFF
--- a/static/components/ExpectedChanges.jsx
+++ b/static/components/ExpectedChanges.jsx
@@ -68,7 +68,7 @@ function ExpectedChanges({changes}) {
     );
 
     return (
-      <li key={resolvedCommit.sha}>
+      <li key={resolvedCommit.oid}>
         <div className="change-title">
           {titleWithoutPr} ({prLink})
         </div>


### PR DESCRIPTION
sha is not a property, it's oid (object ID)