### PR TITLE
fix(ui): Add missing div wrapper for correct commit list styling

### DIFF
--- a/static/components/ExpectedChanges.jsx
+++ b/static/components/ExpectedChanges.jsx
@@ -77,15 +77,17 @@ function ExpectedChanges({changes, markedLabels}) {
 
     return (
       <li key={resolvedCommit.oid} className={classnames({marked: isMarked})}>
-        <div className="change-title">
-          {titleWithoutPr} ({prLink})
+        <div>
+          <div className="change-title">
+            {titleWithoutPr} ({prLink})
+          </div>
+          <div className="change-tags">
+            {author}
+            {commitName}
+            {commitDate}
+          </div>
+          {labels.length > 0 && <div className="change-tags">{labels}</div>}
         </div>
-        <div className="change-tags">
-          {author}
-          {commitName}
-          {commitDate}
-        </div>
-        {labels.length > 0 && <div className="change-tags">{labels}</div>}
       </li>
     );
   });


### PR DESCRIPTION
This should have been included in #369

The div is needed so we don't fade out the pseudo elements on the left making up the commit dots and connecting lines.