### PR TITLE
ref: make the stacktrace less noisy on failures

### DIFF
--- a/bin/run-task
+++ b/bin/run-task
@@ -120,7 +120,7 @@ def main(task_id, log):
         try:
             provider.execute(workspace, task)
         except Exception as exc:
-            current_app.logger.exception(str(exc))
+            current_app.logger.error(str(exc))
             task.status = TaskStatus.failed
         else:
             task.status = TaskStatus.finished

--- a/static/tests/__snapshots__/TaskSummary.test.js.snap
+++ b/static/tests/__snapshots__/TaskSummary.test.js.snap
@@ -81,7 +81,7 @@ exports[`TaskSummary Snapshot 1`] = `
             dateTime="2017-07-13T18:30:45.484Z"
             title="2017-07-13T18:30:45.484Z"
           >
-            5 years ago
+            6 years ago
           </time>
         </TimeSince>
          —


### PR DESCRIPTION
in theory this will just print the error message instead of the full stacktrace which is pretty confusing