### PR TITLE
Revert "feat(ui): Do not show lock notices on app-specific overview"

### DIFF
--- a/static/views/Overview.jsx
+++ b/static/views/Overview.jsx
@@ -61,7 +61,6 @@ function Overview() {
 
   const lockedAlerts = appList
     .filter(a => a.lockedReason !== null)
-    .filter(a => params.app === undefined || a.name === params.app)
     .map(a => (
       <div key={a.name} className="locked-status alert alert-danger">
         <div dangerouslySetInnerHTML={{__html: marked(a.lockedReason)}} />


### PR DESCRIPTION
Reverts getsentry/freight#403

This seems to cause a number of issues breaking the freight UI.

```
Uncaught TypeError: Cannot read properties of undefined (reading 'lockedReason')
    at Tt (LockDeploy.jsx:28:29)
    at ao (react-dom.production.min.js:157:137)
    at Ws (react-dom.production.min.js:267:460)
    at Rl (react-dom.production.min.js:250:347)
    at El (react-dom.production.min.js:250:278)
    at xl (react-dom.production.min.js:250:138)
    at vl (react-dom.production.min.js:243:163)
    at react-dom.production.min.js:123:115
    at t.unstable_runWithPriority (scheduler.production.min.js:18:343)
    at Wi (react-dom.production.min.js:122:325)
    at Vi (react-dom.production.min.js:123:61)
    at qi (react-dom.production.min.js:122:428)
    at Ie (react-dom.production.min.js:292:101)
    at Zt (react-dom.production.min.js:73:352)
```